### PR TITLE
Fix "empty directory listing" bug

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  trailingSlash: true,
 }
 
 module.exports = withTwin(nextConfig)


### PR DESCRIPTION
# Problem

Loading a nested route (ex: `/dashboard`) leads to the following view:
![Screenshot from 2023-05-22 11-56-10](https://github.com/aleph-im/front-aleph-cloud-page/assets/26065817/cf2241d5-2a74-45a9-83c6-0feeaa4d223c)

# Solution 

Tweaking the default nextjs config to not output plain directories without an index.html to avoid directory indexation in IPFS.

## New tree
```
├── dashboard
│   ├── function
│   │   └── index.html
│   ├── index.html
│   ├── manage
│   │   └── index.html
│   └── volume
│       └── index.html
```

## Old tree
```
├── dashboard
│   ├── function.html
│   ├── manage.html
│   └── volume.html
```