### PR TITLE
Feature: Add anchor links on homepage

### DIFF
--- a/src/hooks/useScrollTo.ts
+++ b/src/hooks/useScrollTo.ts
@@ -1,7 +1,17 @@
+import { useRouter } from 'next/router'
 import { RefObject, useCallback, useRef } from 'react'
 
-function getHandleScroll(ref: RefObject<HTMLElement>) {
+function getHandleScroll(
+  ref: RefObject<HTMLElement>,
+  router: ReturnType<typeof useRouter>,
+) {
   if (!ref.current) return
+  if (ref.current.id) {
+    router.push({ hash: ref.current.id }, undefined, {
+      shallow: true,
+      scroll: false,
+    })
+  }
 
   // @note: Fix for sticky header (works better than scroll-margin-top + scrollIntoView)
   const { top } = ref.current.getBoundingClientRect()
@@ -13,8 +23,12 @@ export type UseScrollToReturn = [RefObject<HTMLElement>, () => void]
 export function useScrollTo(_ref?: RefObject<HTMLElement>): UseScrollToReturn {
   const innerRef = useRef(null)
   const ref = _ref || innerRef
+  const router = useRouter()
 
-  const handleScroll = useCallback(() => getHandleScroll(ref), [ref.current])
+  const handleScroll = useCallback(
+    () => getHandleScroll(ref, router),
+    [ref.current],
+  )
 
   return [ref, handleScroll]
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -84,7 +84,7 @@ export default function Home() {
           </Row>
         </Container>
       </section>
-      <section tw="px-0 py-6 md:pb-0 md:pt-20" ref={scroll.function.ref}>
+      <section tw="px-0 py-6 md:pb-0 md:pt-20" ref={scroll.function.ref} id="compute">
         <Container>
           <Row xs={1} md={4} gap="1.5rem">
             <Col xs={1} md={3}>
@@ -166,7 +166,7 @@ export default function Home() {
           </Row>
         </Container>
       </section>
-      <section tw="px-0 pt-12 pb-6 md:pt-20 md:pb-0" ref={scroll.volume.ref}>
+      <section tw="px-0 pt-12 pb-6 md:pt-20 md:pb-0" ref={scroll.volume.ref} id="storage">
         <Container>
           <Row xs={1} md={4} gap="1.5rem">
             <Col xs={1} md={3}>


### PR DESCRIPTION
Addresses the need to link to a specific portion (compute or storage) of the homepage. 

- [x] Add an id to the specific sections to anchor them
- [x] Add a way to push the anchor link in the router while clicking on links that scroll to those section on page (buggy, see notes)

Note: This would potentially break the scrolling effect on some browser as the url change (using browser History API) triggers a viewport location change event, effectively cancelling the scroll.  