### PR TITLE
Fix: Broken build

### DIFF
--- a/.github/workflows/build_check.yaml
+++ b/.github/workflows/build_check.yaml
@@ -1,15 +1,11 @@
-name: Publish
+name: Build Check
 
 on:
-  push:
-    branches:
-      - main
-
-env:
-  IS_GH_PAGES: gh-pages
+  pull_request:
+    branches: [main]
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,11 +26,3 @@ jobs:
           npm config set "//npm.fontawesome.com/:_authToken" FONTAWESOME_NPM_AUTH_TOKEN
           npm ci
           npm run build
-          npm run export
-          touch out/.nojekyll
-
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages
-          folder: out

--- a/src/components/common/FeatureCard/types.ts
+++ b/src/components/common/FeatureCard/types.ts
@@ -1,4 +1,5 @@
 export type FeatureCardProps = {
   children: React.ReactNode
   disabled?: boolean
+  disabledText?: string
 }

--- a/src/components/pages/dashboard/index/AllTabContent/cmp.tsx
+++ b/src/components/pages/dashboard/index/AllTabContent/cmp.tsx
@@ -36,7 +36,7 @@ export const AllTabContent = React.memo(({ data }: AllTabContentProps) => {
                   label: 'Size',
                   align: 'right',
                   sortable: true,
-                  render: (row) => humanReadableSize(row.size, 'mb'),
+                  render: (row) => humanReadableSize(row.size, 'MiB'),
                 },
                 {
                   label: 'Date',

--- a/src/components/pages/dashboard/index/VolumesTabContent/cmp.tsx
+++ b/src/components/pages/dashboard/index/VolumesTabContent/cmp.tsx
@@ -31,7 +31,7 @@ export const VolumesTabContent = React.memo(
                     label: 'Size',
                     align: 'right',
                     sortable: true,
-                    render: (row) => humanReadableSize(row.size || 0, 'mb'),
+                    render: (row) => humanReadableSize(row.size || 0, 'MiB'),
                   },
                   {
                     label: 'Date',

--- a/src/components/pages/dashboard/manage/ManageFunction/cmp.tsx
+++ b/src/components/pages/dashboard/manage/ManageFunction/cmp.tsx
@@ -118,7 +118,7 @@ export default function ManageFunction() {
                 <div className="tp-info text-main0">SIZE</div>
                 <div>
                   <GrayText className="fs-xs tp-body1">
-                    {humanReadableSize(func.size, 'mb')}
+                    {humanReadableSize(func.size, 'MiB')}
                   </GrayText>
                 </div>
               </div>

--- a/src/components/pages/dashboard/manage/ManageVolume/cmp.tsx
+++ b/src/components/pages/dashboard/manage/ManageVolume/cmp.tsx
@@ -100,7 +100,7 @@ export default function ManageVolume() {
                 <div className="tp-info text-main0">SIZE</div>
                 <div>
                   <GrayText className="fs-xs tp-body1">
-                    {humanReadableSize(volume.size, 'mb')}
+                    {humanReadableSize(volume.size, 'MiB')}
                   </GrayText>
                 </div>
               </div>

--- a/src/components/pages/dashboard/manage/VolumeList/cmp.tsx
+++ b/src/components/pages/dashboard/manage/VolumeList/cmp.tsx
@@ -25,7 +25,7 @@ export const VolumeList = React.memo(
                 <div className="tp-info text-main0">PERSISTENT VOLUME</div>
                 <div>
                   <GrayText className="fs-xs tp-body1">
-                    {humanReadableSize(volume.size_mib, 'mb')}
+                    {humanReadableSize(volume.size_mib, 'MiB')}
                   </GrayText>
                 </div>
               </div>
@@ -34,7 +34,7 @@ export const VolumeList = React.memo(
                 <div className="tp-info text-main0">EPHEMERAL VOLUME</div>
                 <div>
                   <GrayText className="fs-xs tp-body1">
-                    {humanReadableSize(volume.size_mib, 'mb')}
+                    {humanReadableSize(volume.size_mib, 'MiB')}
                   </GrayText>
                 </div>
               </div>

--- a/src/domain/volume.ts
+++ b/src/domain/volume.ts
@@ -5,7 +5,6 @@ import {
   EntityType,
   VolumeType,
   defaultVolumeChannel,
-  pricePerMiB,
   programStorageURL,
 } from '../helpers/constants'
 import {

--- a/src/hooks/common/useForm.ts
+++ b/src/hooks/common/useForm.ts
@@ -24,7 +24,9 @@ export type UseFormReturn<
   handleSubmit: (e: FormEvent) => Promise<void>
 }
 
-function getFirstError<T extends FieldValues>(errors: FieldErrors<T>) {
+function getFirstError<T extends FieldValues>(
+  errors: FieldErrors<T>,
+): [string, any] | undefined {
   const [firstError] = Object.entries(errors)
   if (!firstError) return
 


### PR DESCRIPTION
Project could not be built: 
- Type error when calling the `humanReadableSize` with an invalid string (~~mb~~ -> MiB)
- Importing an undefined constant `pricePerMiB`
- Fixed default any on a recursive method (lack of explicit return type)

In order to prevent this from further happening, I added an action that builds the project when opening a PR.