### PR TITLE
Fix: Volume price calculation

### DIFF
--- a/src/domain/volume.ts
+++ b/src/domain/volume.ts
@@ -123,13 +123,13 @@ export class VolumeManager implements EntityManager<Volume, AddVolume> {
   }
 
   /**
-   * Returns the size of a volume in mb
+   * Returns the price per mb of a volume
    */
   static getVolumeMiBPrice(volume: Volume | AddVolume): number {
-    if (volume.volumeType !== VolumeType.New) return 20
-    if (volume.mountPath) return 20
-
-    return 1 / 3
+    // Volume is always 20 ALEPH per mb
+    // If it's a new volume you also pay for the storage (1/3 ALEPH per mb)
+    if (volume.volumeType === VolumeType.New) return 20 + 1 / 3
+    return 20
   }
 
   // @note: The algorithm for calculating the cost per volume is as follows:


### PR DESCRIPTION
## Problem description

Adding a volume (after the free volume allowance provided by the compute unit) should always be 20 ALEPH/Mb. If it's a new Volume, we add 3 MB/Aleph for the extra storage cost.

## Screenshot

Here is the result with a 5.19GB file. 

![image](https://github.com/aleph-im/front-aleph-cloud-page/assets/26065817/078c83bd-18b6-4844-a2bd-3a56957e38ad)
