### PR TITLE
Feature: User can now chose an entrypoint for their program

### DIFF
--- a/src/components/form/AddFunctionCode/cmp.tsx
+++ b/src/components/form/AddFunctionCode/cmp.tsx
@@ -129,7 +129,7 @@ export const AddFunctionCode = React.memo((props: AddFunctionCodeProps) => {
                     </div>
                   }
                 >
-                  <div tw='my-3'>Entry point</div>
+                  <div tw="my-3">Entry point</div>
                 </InfoTooltipButton>
                 <TextInput
                   {...entryPointCtrl.field}

--- a/src/components/form/AddFunctionCode/cmp.tsx
+++ b/src/components/form/AddFunctionCode/cmp.tsx
@@ -108,7 +108,9 @@ export const AddFunctionCode = React.memo((props: AddFunctionCodeProps) => {
                   Upload code <Icon name="arrow-up" tw="ml-4" />
                 </HiddenFileInput>
               </div>
+            </NoisyContainer>
 
+            <NoisyContainer tw="mt-6">
               <div>
                 <InfoTooltipButton
                   plain
@@ -127,7 +129,7 @@ export const AddFunctionCode = React.memo((props: AddFunctionCodeProps) => {
                     </div>
                   }
                 >
-                  Entry point
+                  <div tw='my-3'>Entry point</div>
                 </InfoTooltipButton>
                 <TextInput
                   {...entryPointCtrl.field}

--- a/src/components/form/AddFunctionCode/cmp.tsx
+++ b/src/components/form/AddFunctionCode/cmp.tsx
@@ -8,12 +8,14 @@ import {
   Radio,
   RadioGroup,
   Tabs,
+  TextInput,
 } from '@aleph-front/aleph-core'
 import NoisyContainer from '@/components/common/NoisyContainer'
 import { useAddFunctionCode } from '@/hooks/form/useAddFunctionCode'
 
 export const AddFunctionCode = React.memo((props: AddFunctionCodeProps) => {
-  const { langCtrl, typeCtrl, textCtrl, fileCtrl } = useAddFunctionCode(props)
+  const { langCtrl, typeCtrl, textCtrl, fileCtrl, entryPointCtrl } =
+    useAddFunctionCode(props)
 
   return (
     <>
@@ -95,14 +97,9 @@ export const AddFunctionCode = React.memo((props: AddFunctionCodeProps) => {
               To get started, compress your code into a zip file and upload it
               here.
             </p>
-            <p tw="mb-6">
-              Your zip archive should contain a{' '}
-              <strong tw="font-bold">main</strong> file (ex: main.py) at its
-              root that exposes an <strong tw="font-bold">app</strong> function.
-              This will serve as an entrypoint to the program
-            </p>
+
             <NoisyContainer>
-              <div tw="py-5 text-center">
+              <div tw="mb-6 py-5 text-center">
                 <HiddenFileInput
                   {...fileCtrl.field}
                   {...fileCtrl.fieldState}
@@ -110,6 +107,33 @@ export const AddFunctionCode = React.memo((props: AddFunctionCodeProps) => {
                 >
                   Upload code <Icon name="arrow-up" tw="ml-4" />
                 </HiddenFileInput>
+              </div>
+
+              <div>
+                <InfoTooltipButton
+                  plain
+                  my="bottom-left"
+                  at="bottom-right"
+                  tooltipContent={
+                    <div tw="text-left">
+                      <div>
+                        <div className="tp-body2 fs-md">Entrypoint</div>
+                        <div className="tp-body1 fs-md">
+                          Define an entrypoint to your program. For example if
+                          you have a file called main.py and a function called
+                          app, you should enter main:app.
+                        </div>
+                      </div>
+                    </div>
+                  }
+                >
+                  Entry point
+                </InfoTooltipButton>
+                <TextInput
+                  {...entryPointCtrl.field}
+                  {...entryPointCtrl.fieldState}
+                  placeholder="main:app"
+                />
               </div>
             </NoisyContainer>
           </>

--- a/src/helpers/schemas.ts
+++ b/src/helpers/schemas.ts
@@ -141,6 +141,7 @@ export const addCodeSchema = z.discriminatedUnion('type', [
   defaultCode.extend({
     type: z.literal('file'),
     file: codeFile,
+    entrypoint: requiredString,
   }),
   defaultCode.extend({
     type: z.literal('text'),

--- a/src/hooks/form/useAddFunctionCode.ts
+++ b/src/hooks/form/useAddFunctionCode.ts
@@ -12,7 +12,7 @@ export const defaultCode: FunctionCodeField = {
   lang: 'python',
   type: 'text',
   text: defaultText,
-  entryPoint: 'main:app',
+  entrypoint: 'main:app',
 }
 
 export type FunctionCodeField = {
@@ -22,13 +22,13 @@ export type FunctionCodeField = {
       type: 'text'
       text: string
       file?: File
-      entryPoint?: string
+      entrypoint?: string
     }
   | {
       type: 'file'
       file: File
       text?: string
-      entryPoint?: string
+      entrypoint: string
     }
 )
 
@@ -59,8 +59,8 @@ export function useAddFunctionCode({
 
   const entryPointCtrl = useController({
     control,
-    name: `${name}.entryPoint`,
-    defaultValue: defaultValue?.entryPoint,
+    name: `${name}.entrypoint`,
+    defaultValue: defaultValue?.entrypoint,
   })
 
   const typeCtrl = useController({

--- a/src/hooks/form/useAddFunctionCode.ts
+++ b/src/hooks/form/useAddFunctionCode.ts
@@ -12,6 +12,7 @@ export const defaultCode: FunctionCodeField = {
   lang: 'python',
   type: 'text',
   text: defaultText,
+  entryPoint: 'main:app',
 }
 
 export type FunctionCodeField = {
@@ -21,11 +22,13 @@ export type FunctionCodeField = {
       type: 'text'
       text: string
       file?: File
+      entryPoint?: string
     }
   | {
       type: 'file'
       file: File
       text?: string
+      entryPoint?: string
     }
 )
 
@@ -40,6 +43,7 @@ export type UseAddFunctionCodeReturn = {
   typeCtrl: UseControllerReturn<any, any>
   fileCtrl: UseControllerReturn<any, any>
   textCtrl: UseControllerReturn<any, any>
+  entryPointCtrl: UseControllerReturn<any, any>
 }
 
 export function useAddFunctionCode({
@@ -51,6 +55,12 @@ export function useAddFunctionCode({
     control,
     name: `${name}.lang`,
     defaultValue: defaultValue?.lang,
+  })
+
+  const entryPointCtrl = useController({
+    control,
+    name: `${name}.entryPoint`,
+    defaultValue: defaultValue?.entryPoint,
   })
 
   const typeCtrl = useController({
@@ -76,5 +86,6 @@ export function useAddFunctionCode({
     typeCtrl,
     fileCtrl,
     textCtrl,
+    entryPointCtrl,
   }
 }


### PR DESCRIPTION
Closes #43

- Entrypoint cas be selected under the `Upload code` section
- Entrypoint is not needed when using the online editor
- Entrypoint could be any string, but cannot be empty (mandatory field)

# Screenshots:
![Screenshot from 2023-09-08 14-31-39](https://github.com/aleph-im/front-aleph-cloud-page/assets/26065817/44232f0b-7714-4b85-8b09-b51fb09689bc)


![Screenshot from 2023-09-08 14-31-48](https://github.com/aleph-im/front-aleph-cloud-page/assets/26065817/2be78269-5e91-4f58-812b-9d58504f02c8)
