### PR TITLE
[FIXED] Issue 34: Listener added to wallet provider in order to detect account changed

### DIFF
--- a/src/components/common/Header/cmp.tsx
+++ b/src/components/common/Header/cmp.tsx
@@ -10,8 +10,9 @@ import Link from 'next/link'
 import { StyledHeader, StyledButton, StyledNavbar } from './styles'
 import { ellipseAddress } from '@/helpers/utils'
 import { useHeader } from '@/hooks/pages/useHeader'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useOnClickOutside } from 'usehooks-ts'
+import { useConnect } from '@/hooks/common/useConnect'
 
 export const Header = () => {
   const {
@@ -23,6 +24,8 @@ export const Header = () => {
     setDisplayWalletPicker,
     accountBalance,
   } = useHeader()
+
+  const { connect } = useConnect()
   const divRef = useRef<HTMLDivElement | null>(null)
   useOnClickOutside(divRef, () => {
     if (displayWalletPicker) setDisplayWalletPicker(false)
@@ -31,6 +34,23 @@ export const Header = () => {
   const handleDisplayWalletPicker = () => {
     setDisplayWalletPicker(!displayWalletPicker)
   }
+
+  const provider = () => {
+    window.ethereum.on('accountsChanged', function () {
+      connect()
+    })
+
+    return window.ethereum
+  }
+
+  useEffect(() => {
+    provider()
+    return () => {
+      window.ethereum.removeListener('accountsChanged', () => {
+        connect()
+      })
+    }
+  })
 
   return (
     <StyledHeader>
@@ -124,7 +144,7 @@ export const Header = () => {
                             color: 'orange',
                             icon: 'circle',
                             name: 'Metamask',
-                            provider: () => window.ethereum,
+                            provider: () => provider(),
                           },
                         ],
                       },


### PR DESCRIPTION
This pull request fixes the issue mentioned in #34 . The issue was related to detecting and reloading when the Ethereum account changes from the wallet provider.

**Changes Made**:
- Added an event listener to `window.ethereum` to detect changes in Ethereum accounts.
- When the `accountsChanged` event is triggered, it reloads the interface with the updated Ethereum account.
```{js}
window.ethereum.on('accountsChanged', function (accounts) {
  // Time to reload interface with accounts[0]!
})
```

**Test Plan**:
- [ ] Tested the code changes locally to ensure they function as expected.
- [ ] Checked for any potential side effects.

**Screenshots**:

Adapts to the entire application, here is an example after changing account the requirements are updated and the button becomes active

<img width="850" alt="Screenshot 2023-09-21 à 11 11 05" src="https://github.com/aleph-im/front-aleph-cloud-page/assets/17054452/b51cb492-8c81-4c80-960c-795182a939a6">

<img width="826" alt="Screenshot 2023-09-21 à 11 11 58" src="https://github.com/aleph-im/front-aleph-cloud-page/assets/17054452/18efc44a-80cb-4cef-80e1-298ac6997cc5">
