### PR TITLE
Allow .squasfs file suffix in volume upload

### DIFF
--- a/src/components/pages/dashboard/NewVolumePage/cmp.tsx
+++ b/src/components/pages/dashboard/NewVolumePage/cmp.tsx
@@ -35,8 +35,8 @@ export default function NewVolumePage() {
         unlockedAmount={accountBalance}
         description={
           <>
-            This amount needs to be present in your wallet until the function is
-            removed. Tokens won &#39;t be locked nor consumed. The function will
+            This amount needs to be present in your wallet until the volume is
+            removed. Tokens won &#39;t be locked nor consumed. The volume will
             be garbage collected once funds are removed from the wallet.
           </>
         }

--- a/src/helpers/schemas.ts
+++ b/src/helpers/schemas.ts
@@ -34,10 +34,11 @@ const volumeFile = z
     (file) => {
       return (
         (file.type === 'application/zip' && file.name.endsWith('.zip')) ||
-        file.name.endsWith('.sqsh')
+        file.name.endsWith('.sqsh') ||
+        file.name.endsWith('.squashfs')
       )
     },
-    { message: 'only .zip and .sqsh formats are valid' },
+    { message: 'only .zip, .sqsh and .squashfs formats are valid' },
   )
   .refine((file) => file.size > 0, {
     message: 'File size should be greater than 0',
@@ -50,10 +51,11 @@ const codeFile = z
       console.log(file)
       return (
         (file.type === 'application/zip' && file.name.endsWith('.zip')) ||
-        file.name.endsWith('.sqsh')
+        file.name.endsWith('.sqsh') ||
+        file.name.endsWith('.squashfs')
       )
     },
-    { message: 'only .zip and .sqsh formats are valid' },
+    { message: 'only .zip, .sqsh and .squashfs formats are valid' },
   )
   .refine((file) => file.size > 0, {
     message: 'File size should be greater than 0',


### PR DESCRIPTION
`.squashfs` is a common file suffix for squashFS files, just like `.sqsh`.

Also, fixed a typo where it looked like you were uploading a function, not a volume.