### PR TITLE
Allow unconnected users to browse Dapp 

### DIFF
--- a/src/components/pages/dashboard/NewFunctionPage/cmp.tsx
+++ b/src/components/pages/dashboard/NewFunctionPage/cmp.tsx
@@ -1,4 +1,10 @@
-import { Button, Tabs, TextGradient } from '@aleph-front/aleph-core'
+import {
+  Button,
+  Tabs,
+  TextGradient,
+  Icon,
+  WalletPicker,
+} from '@aleph-front/aleph-core'
 import { EntityType } from '@/helpers/constants'
 import CompositeTitle from '@/components/common/CompositeTitle'
 import { useNewFunctionPage } from '@/hooks/pages/dashboard/useNewFunctionPage'
@@ -16,6 +22,7 @@ import { convertByteUnits } from '@/helpers/utils'
 import Form from '@/components/form/Form'
 import ToggleContainer from '@/components/common/ToggleContainer'
 import SelectCustomFunctionRuntime from '@/components/form/SelectCustomFunctionRuntime/cmp'
+import { useHeader } from '@/hooks/pages/useHeader'
 
 export default function NewFunctionPage() {
   const {
@@ -28,6 +35,43 @@ export default function NewFunctionPage() {
     handleSubmit,
     handleChangeEntityTab,
   } = useNewFunctionPage()
+
+  const {
+    theme,
+    account,
+    displayWalletPicker,
+    divRef,
+    handleConnect,
+    handleDisplayWalletPicker,
+    provider,
+  } = useHeader()
+
+  const WalletPickerComponent = () => {
+    return (
+      <WalletPicker
+        networks={[
+          {
+            icon: 'ethereum',
+            name: 'Ethereum',
+            wallets: [
+              {
+                color: 'orange',
+                icon: 'circle',
+                name: 'Metamask',
+                provider,
+              },
+            ],
+          },
+        ]}
+        onConnect={handleConnect}
+        onDisconnect={handleConnect}
+        address={account?.address}
+        addressHref={`https://etherscan.io/address/${account?.address}`}
+        balance={accountBalance}
+        size="regular"
+      />
+    )
+  }
 
   return (
     <Form onSubmit={handleSubmit} errors={errors}>
@@ -204,16 +248,43 @@ export default function NewFunctionPage() {
           </>
         }
         button={
-          <Button
-            type="submit"
-            color="main0"
-            kind="neon"
-            size="big"
-            variant="primary"
-            disabled={isCreateButtonDisabled}
-          >
-            Create function
-          </Button>
+          <>
+            {address ? (
+              <Button
+                type="submit"
+                color="main0"
+                kind="neon"
+                size="big"
+                variant="primary"
+                disabled={isCreateButtonDisabled}
+              >
+                Create function
+              </Button>
+            ) : (
+              <>
+                <Button
+                  as="button"
+                  type="button"
+                  variant="tertiary"
+                  color="main0"
+                  kind="neon"
+                  size="regular"
+                  onClick={handleDisplayWalletPicker}
+                >
+                  Connect{' '}
+                  <Icon
+                    name="meteor"
+                    size="lg"
+                    tw="ml-2.5"
+                    color={theme.color.main0}
+                  />
+                </Button>
+                <div tw="flex justify-center my-6" ref={divRef}>
+                  {displayWalletPicker && WalletPickerComponent()}
+                </div>
+              </>
+            )}
+          </>
         }
       />
     </Form>

--- a/src/hooks/common/useConnectedWard.ts
+++ b/src/hooks/common/useConnectedWard.ts
@@ -10,10 +10,4 @@ import { useAppState } from '@/contexts/appState'
 export default function useConnectedWard(route = '/') {
   const [state] = useAppState()
   const router = useRouter()
-
-  useEffect(() => {
-    if (!state.account) {
-      router.replace(route)
-    }
-  })
 }

--- a/src/hooks/pages/useHeader.ts
+++ b/src/hooks/pages/useHeader.ts
@@ -50,9 +50,6 @@ export function useHeader(): UseHeaderReturn {
   const handleConnect = useCallback(async () => {
     if (!isConnected) {
       setkeepAccountAlive(true)
-      const acc = await connect()
-      if (!acc) return
-      router.push('/dashboard')
     } else {
       setkeepAccountAlive(false)
       await disconnect()


### PR DESCRIPTION
Linked to this issue #21 

**Description:**
This pull request aims to enhance the user experience by removing the requirement for users to be connected in order to browse the Dapp and create instances. It introduces changes to the application flow to facilitate access for unconnected users while maintaining the necessary functionalities related to instance creation.

**Changes:**

- Allow Unconnected Browsing: Users can now access and browse the Dapp without requiring a prior connection.
- Streamlined Instance Creation Process: Modified the instance creation process to function seamlessly for unconnected users.
- User Experience Enhancement: Ensured a smoother flow for unconnected users while preserving the necessary authentication steps during critical operations.
**Benefits:**

Improved accessibility for users, allowing them to explore the Dapp and initiate the instance creation process without the barrier of mandatory prior connection.
Enhanced user experience by streamlining the onboarding process.

**Screenshots:**
<img width="1677" alt="Capture d’écran 2023-11-03 à 08 59 29" src="https://github.com/aleph-im/front-aleph-cloud-page/assets/17054452/6d3de7d8-b1c9-4f41-903f-abc1873ed6f1">

<img width="1662" alt="Capture d’écran 2023-11-03 à 09 00 06" src="https://github.com/aleph-im/front-aleph-cloud-page/assets/17054452/b1fe10ca-d8ef-4911-ae62-f694c1b9b9f0">

<img width="1687" alt="Capture d’écran 2023-11-03 à 08 59 56" src="https://github.com/aleph-im/front-aleph-cloud-page/assets/17054452/a8379584-d503-4fc3-9bae-0f24fd6b0d1c">

**Code:**
I removed the redirection from `useConnectedWard.ts` file

```{js}
export default function useConnectedWard(route = '/') {
  const [state] = useAppState()
  const router = useRouter()

  useEffect(() => {
    if (!state.account) {
      router.replace(route)
    }
  })
}
```

And add same button as Header at the end of instance creation process



