### PR TITLE
Aleph-VM does not support plain encoding for PROGRAM src

### DIFF
--- a/src/domain/program.ts
+++ b/src/domain/program.ts
@@ -1,3 +1,4 @@
+import JSZip from 'jszip'
 import { Account } from 'aleph-sdk-ts/dist/accounts/account'
 import { forget, program, any } from 'aleph-sdk-ts/dist/messages'
 // import { ProgramPublishConfiguration } from 'aleph-sdk-ts/dist/messages/program/publish'
@@ -216,10 +217,15 @@ export class ProgramManager
 
   protected async parseCode(code: FunctionCodeField): Promise<ParsedCodeType> {
     if (code.type === 'text') {
+      const jsZip = new JSZip()
+      const fileExt = code.lang === FunctionLangId.Python ? 'py' : 'js'
+      jsZip.file('main.' + fileExt, code.text)
+      const zip = await jsZip.generateAsync({ type: 'blob' })
+
       return {
         entrypoint: 'main:app',
-        file: new Blob([code.text], { type: 'text/plain' }) as File,
-        encoding: Encoding.plain,
+        file: zip as File,
+        encoding: Encoding.zip,
       }
     } else if (code.type === 'file') {
       if (!code.file) throw new Error('Invalid function code file')


### PR DESCRIPTION
# Problem description

While Aleph-vm technically support plain encoding for program source, it does not seem to work as is.

# Fix

As a temporary fix, send the program source as a zipped file

# Ref

This fixes a regression that was potentially introduced in #56 