### PR TITLE
Fix: Domain aggregate message for function/instance

### DIFF
--- a/src/components/form/AddDomains/types.ts
+++ b/src/components/form/AddDomains/types.ts
@@ -1,4 +1,4 @@
-import { EntityType } from '@/helpers/constants'
+import { EntityDomainType } from '@/helpers/constants'
 import { Control } from 'react-hook-form'
 
 export type DomainItemProps = {
@@ -11,5 +11,5 @@ export type DomainItemProps = {
 export type AddDomainsProps = {
   control: Control
   name: string
-  entityType: EntityType.Program | EntityType.Instance
+  entityType: EntityDomainType
 }

--- a/src/components/pages/dashboard/ManageDomain/cmp.tsx
+++ b/src/components/pages/dashboard/ManageDomain/cmp.tsx
@@ -1,6 +1,6 @@
 import IconText from '@/components/common/IconText'
 import { NoisyContainer } from '@aleph-front/aleph-core'
-import { EntityTypeName, AddDomainTarget } from '@/helpers/constants'
+import { EntityTypeName, EntityDomainType } from '@/helpers/constants'
 import {
   BulletItem,
   Button,
@@ -152,17 +152,17 @@ export default function ManageDomain() {
                               {domain.name}
                             </span>
                             with value
-                            {domain.target == AddDomainTarget.Program && (
+                            {domain.target == EntityDomainType.Program && (
                               <span className="text-main0" tw="mx-2">
                                 {domain.name}.program.public.aleph.sh.
                               </span>
                             )}
-                            {domain.target == AddDomainTarget.Instance && (
+                            {domain.target == EntityDomainType.Instance && (
                               <span className="text-main0" tw="mx-2">
                                 {domain.name}.instance.public.aleph.sh.
                               </span>
                             )}
-                            {domain.target == AddDomainTarget.IPFS && (
+                            {domain.target == EntityDomainType.IPFS && (
                               <span className="text-main0" tw="mx-2">
                                 ipfs.public.aleph.sh.
                               </span>
@@ -170,7 +170,7 @@ export default function ManageDomain() {
                           </div>
                         </div>
                       </GrayText>
-                      {domain.target == AddDomainTarget.IPFS && (
+                      {domain.target == EntityDomainType.IPFS && (
                         <GrayText>
                           <div tw="flex mt-2">
                             <BulletItem

--- a/src/components/pages/dashboard/NewDomainPage/cmp.tsx
+++ b/src/components/pages/dashboard/NewDomainPage/cmp.tsx
@@ -4,7 +4,11 @@ import Container from '@/components/common/CenteredContainer'
 import ExternalLinkButton from '@/components/common/ExternalLinkButton'
 import { NoisyContainer } from '@aleph-front/aleph-core'
 import Form from '@/components/form/Form'
-import { EntityType, EntityTypeName, AddDomainTarget } from '@/helpers/constants'
+import {
+  EntityType,
+  EntityTypeName,
+  AddDomainTarget,
+} from '@/helpers/constants'
 import { useNewDomainPage } from '@/hooks/pages/dashboard/useNewDomainPage'
 import {
   Button,
@@ -28,14 +32,14 @@ export default function NewDomain() {
     refCtrl,
     errors,
     handleSubmit,
-    setTarget
+    setTarget,
   } = useNewDomainPage()
 
   const [tabId, setTabId] = useState('compute')
 
   const onTabChange = (tabId) => {
     setTabId(tabId)
-    if (tabId == "ipfs") {
+    if (tabId == 'ipfs') {
       setTarget(AddDomainTarget.IPFS)
     } else {
       setTarget(AddDomainTarget.INSTANCE)

--- a/src/components/pages/dashboard/NewDomainPage/cmp.tsx
+++ b/src/components/pages/dashboard/NewDomainPage/cmp.tsx
@@ -4,7 +4,7 @@ import Container from '@/components/common/CenteredContainer'
 import ExternalLinkButton from '@/components/common/ExternalLinkButton'
 import { NoisyContainer } from '@aleph-front/aleph-core'
 import Form from '@/components/form/Form'
-import { EntityType, EntityTypeName } from '@/helpers/constants'
+import { EntityType, EntityTypeName, AddDomainTarget } from '@/helpers/constants'
 import { useNewDomainPage } from '@/hooks/pages/dashboard/useNewDomainPage'
 import {
   Button,
@@ -24,14 +24,23 @@ export default function NewDomain() {
     hasFunctions,
     hasInstances,
     nameCtrl,
-    programTypeCtrl,
+    targetCtrl,
     refCtrl,
-    ipfsRefCtrl,
     errors,
     handleSubmit,
+    setTarget
   } = useNewDomainPage()
 
   const [tabId, setTabId] = useState('compute')
+
+  const onTabChange = (tabId) => {
+    setTabId(tabId)
+    if (tabId == "ipfs") {
+      setTarget(AddDomainTarget.IPFS)
+    } else {
+      setTarget(AddDomainTarget.INSTANCE)
+    }
+  }
 
   return (
     <>
@@ -95,7 +104,7 @@ export default function NewDomain() {
                   <Tabs
                     align="left"
                     selected={tabId}
-                    onTabChange={setTabId}
+                    onTabChange={onTabChange}
                     tabs={[
                       {
                         id: 'compute',
@@ -112,8 +121,8 @@ export default function NewDomain() {
                   {tabId === 'compute' ? (
                     <NoisyContainer tw="z-10!">
                       <RadioGroup
-                        {...programTypeCtrl.field}
-                        {...programTypeCtrl.fieldState}
+                        {...targetCtrl.field}
+                        {...targetCtrl.fieldState}
                         required
                         label="Choose resource type"
                         direction="row"
@@ -154,8 +163,8 @@ export default function NewDomain() {
                       </p>
                       <NoisyContainer>
                         <TextInput
-                          {...ipfsRefCtrl.field}
-                          {...ipfsRefCtrl.fieldState}
+                          {...refCtrl.field}
+                          {...refCtrl.fieldState}
                           required
                           label="Link your custom domain to an Aleph Message ID"
                           placeholder="Paste your IPFS Aleph Message ID"

--- a/src/components/pages/dashboard/NewDomainPage/cmp.tsx
+++ b/src/components/pages/dashboard/NewDomainPage/cmp.tsx
@@ -4,11 +4,7 @@ import Container from '@/components/common/CenteredContainer'
 import ExternalLinkButton from '@/components/common/ExternalLinkButton'
 import { NoisyContainer } from '@aleph-front/aleph-core'
 import Form from '@/components/form/Form'
-import {
-  EntityType,
-  EntityTypeName,
-  AddDomainTarget,
-} from '@/helpers/constants'
+import { EntityDomainTypeName, EntityDomainType } from '@/helpers/constants'
 import { useNewDomainPage } from '@/hooks/pages/dashboard/useNewDomainPage'
 import {
   Button,
@@ -37,12 +33,12 @@ export default function NewDomain() {
 
   const [tabId, setTabId] = useState('compute')
 
-  const onTabChange = (tabId) => {
+  const onTabChange = (tabId: string) => {
     setTabId(tabId)
     if (tabId == 'ipfs') {
-      setTarget(AddDomainTarget.IPFS)
+      setTarget(EntityDomainType.IPFS)
     } else {
-      setTarget(AddDomainTarget.INSTANCE)
+      setTarget(EntityDomainType.Instance)
     }
   }
 
@@ -132,13 +128,15 @@ export default function NewDomain() {
                         direction="row"
                       >
                         <Radio
-                          label={EntityTypeName[EntityType.Instance]}
-                          value={EntityType.Instance}
+                          label={
+                            EntityDomainTypeName[EntityDomainType.Instance]
+                          }
+                          value={EntityDomainType.Instance}
                           disabled={!hasInstances}
                         />
                         <Radio
-                          label={EntityTypeName[EntityType.Program]}
-                          value={EntityType.Program}
+                          label={EntityDomainTypeName[EntityDomainType.Program]}
+                          value={EntityDomainType.Program}
                           disabled={!hasFunctions}
                         />
                       </RadioGroup>

--- a/src/components/pages/dashboard/NewFunctionPage/cmp.tsx
+++ b/src/components/pages/dashboard/NewFunctionPage/cmp.tsx
@@ -1,5 +1,9 @@
 import { Button, TextGradient, CompositeTitle } from '@aleph-front/aleph-core'
-import { EntityType, PaymentMethod } from '@/helpers/constants'
+import {
+  EntityType,
+  PaymentMethod,
+  EntityDomainType,
+} from '@/helpers/constants'
 import { useNewFunctionPage } from '@/hooks/pages/dashboard/useNewFunctionPage'
 import HoldingRequirements from '@/components/form/HoldingRequirements'
 import SelectInstanceSpecs from '@/components/form/SelectInstanceSpecs'
@@ -158,7 +162,7 @@ export default function NewFunctionPage() {
                 <AddDomains
                   name="domains"
                   control={control}
-                  entityType={EntityType.Program}
+                  entityType={EntityDomainType.Program}
                 />
               </ToggleContainer>
             </div>

--- a/src/components/pages/dashboard/NewInstanceHoldPage/cmp.tsx
+++ b/src/components/pages/dashboard/NewInstanceHoldPage/cmp.tsx
@@ -7,7 +7,11 @@ import AddSSHKeys from '@/components/form/AddSSHKeys'
 import AddDomains from '@/components/form/AddDomains'
 import AddNameAndTags from '@/components/form/AddNameAndTags'
 import HoldingRequirements from '@/components/form/HoldingRequirements'
-import { EntityType, PaymentMethod } from '@/helpers/constants'
+import {
+  EntityType,
+  PaymentMethod,
+  EntityDomainType,
+} from '@/helpers/constants'
 import Container from '@/components/common/CenteredContainer'
 import { useNewInstanceHoldPage } from '@/hooks/pages/dashboard/useNewInstanceHoldPage'
 import Form from '@/components/form/Form'
@@ -144,7 +148,7 @@ export default function NewInstanceHoldPage() {
                 <AddDomains
                   name="domains"
                   control={control}
-                  entityType={EntityType.Instance}
+                  entityType={EntityDomainType.Instance}
                 />
               </ToggleContainer>
             </div>

--- a/src/components/pages/dashboard/NewInstanceStreamPage/cmp.tsx
+++ b/src/components/pages/dashboard/NewInstanceStreamPage/cmp.tsx
@@ -15,7 +15,7 @@ import AddSSHKeys from '@/components/form/AddSSHKeys'
 import AddDomains from '@/components/form/AddDomains'
 import AddNameAndTags from '@/components/form/AddNameAndTags'
 import HoldingRequirements from '@/components/form/HoldingRequirements'
-import { EntityType, apiServer } from '@/helpers/constants'
+import { EntityType, apiServer, EntityDomainType } from '@/helpers/constants'
 import Container from '@/components/common/CenteredContainer'
 import { useNewInstanceStreamPage } from '@/hooks/pages/dashboard/useNewInstanceStreamPage'
 import Form from '@/components/form/Form'
@@ -221,7 +221,7 @@ export default function NewInstancePage() {
                 <AddDomains
                   name="domains"
                   control={control}
-                  entityType={EntityType.Instance}
+                  entityType={EntityDomainType.Instance}
                 />
               </ToggleContainer>
             </div>

--- a/src/domain/domain.ts
+++ b/src/domain/domain.ts
@@ -112,9 +112,6 @@ export class DomainManager implements EntityManager<Domain, AddDomain> {
       const content: DomainAggregate = domains.reduce((ac, cv) => {
         const { name, ref, target, programType } = cv
 
-        console.log('programType', programType)
-        console.log('target', target)
-
         const domain = {
           message_id: ref,
           programType,

--- a/src/domain/domain.ts
+++ b/src/domain/domain.ts
@@ -2,7 +2,7 @@ import { Account } from 'aleph-sdk-ts/dist/accounts/account'
 import { aggregate } from 'aleph-sdk-ts/dist/messages'
 import E_ from '../helpers/errors'
 import {
-  AddDomainTarget,
+  EntityDomainType,
   EntityType,
   apiServer,
   defaultDomainAggregateKey,
@@ -11,10 +11,10 @@ import {
 import { EntityManager } from './types'
 import { domainSchema, domainsSchema } from '@/helpers/schemas/domain'
 
-export { AddDomainTarget }
+export { EntityDomainType }
 
 export type DomainAggregateItem = {
-  type: AddDomainTarget
+  type: EntityDomainType
   message_id: string
   updated_at: string
 }
@@ -23,11 +23,11 @@ export type DomainAggregate = Record<string, DomainAggregateItem | null>
 
 export type AddDomain = {
   name: string
-  target: AddDomainTarget
+  target: EntityDomainType
   ref: string
 }
 
-export type Domain = Omit<AddDomain, 'target'> & {
+export type Domain = AddDomain & {
   type: EntityType.Domain
   id: string
   confirmed?: boolean

--- a/src/domain/domain.ts
+++ b/src/domain/domain.ts
@@ -14,7 +14,7 @@ import { domainSchema, domainsSchema } from '@/helpers/schemas/domain'
 export { AddDomainTarget }
 
 export type DomainAggregateItem = {
-  type: AddDomainTarget
+  type: AddDomainTarget | EntityType.Program | EntityType.Instance
   message_id: string
   programType?: EntityType.Instance | EntityType.Program
   updated_at: string
@@ -24,8 +24,8 @@ export type DomainAggregate = Record<string, DomainAggregateItem | null>
 
 export type AddDomain = {
   name: string
-  target: AddDomainTarget
-  programType?: EntityType.Instance | EntityType.Program
+  target: AddDomainTarget | EntityType.Program | EntityType.Instance
+  programType: EntityType.Instance | EntityType.Program
   ref: string
 }
 
@@ -112,23 +112,19 @@ export class DomainManager implements EntityManager<Domain, AddDomain> {
       const content: DomainAggregate = domains.reduce((ac, cv) => {
         const { name, ref, target, programType } = cv
 
+        console.log('programType', programType)
+        console.log('target', target)
+
         const domain = {
           message_id: ref,
           programType,
-          type: target,
+          type: target === AddDomainTarget.IPFS ? target : programType,
           updated_at: new Date().toISOString(),
         }
 
         // @note: legacy domains don't include programType (default to Instance)
         if (target === AddDomainTarget.Program) {
           domain.programType = cv.programType || EntityType.Instance
-        }
-
-        // @note: temporary dirty fix
-        if (programType !== undefined) {
-          // @fixme:
-          // Those two enums are overlapping even though they do not share the same reference
-          domain.type = programType as unknown as AddDomainTarget
         }
 
         ac[name] = domain

--- a/src/domain/domain.ts
+++ b/src/domain/domain.ts
@@ -124,6 +124,13 @@ export class DomainManager implements EntityManager<Domain, AddDomain> {
           domain.programType = cv.programType || EntityType.Instance
         }
 
+        // @note: temporary dirty fix
+        if (programType !== undefined) {
+          // @fixme:
+          // Those two enums are overlapping even though they do not share the same reference
+          domain.type = programType as unknown as AddDomainTarget
+        }
+
         ac[name] = domain
 
         return ac

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -61,10 +61,16 @@ export enum EntityType {
   Indexer = 'indexer',
 }
 
-export enum AddDomainTarget {
+export enum EntityDomainType {
   IPFS = 'ipfs',
   Program = 'program',
   Instance = 'instance',
+}
+
+export const EntityDomainTypeName: Record<EntityDomainType, string> = {
+  [EntityDomainType.IPFS]: 'Ipfs',
+  [EntityDomainType.Program]: 'Function',
+  [EntityDomainType.Instance]: 'Instance',
 }
 
 export enum VolumeType {

--- a/src/helpers/schemas/base.ts
+++ b/src/helpers/schemas/base.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { EntityType, PaymentMethod } from '../constants'
+import { PaymentMethod } from '../constants'
 
 export const requiredStringSchema = z
   .string()

--- a/src/helpers/schemas/base.ts
+++ b/src/helpers/schemas/base.ts
@@ -83,11 +83,6 @@ export const ipfsCIDSchema = requiredStringSchema.regex(
   { message: 'Invalid IPFS CID hash' },
 )
 
-export const programTypeSchema = z.enum([
-  EntityType.Instance,
-  EntityType.Program,
-])
-
 export const paymentMethodSchema = z.enum([
   PaymentMethod.Hold,
   PaymentMethod.Stream,

--- a/src/helpers/schemas/domain.ts
+++ b/src/helpers/schemas/domain.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { domainNameSchema, messageHashSchema, programTypeSchema } from './base'
+import { domainNameSchema, messageHashSchema } from './base'
 import { AddDomainTarget } from '../constants'
 
 // DOMAINS

--- a/src/helpers/schemas/domain.ts
+++ b/src/helpers/schemas/domain.ts
@@ -1,15 +1,15 @@
 import { z } from 'zod'
 import { domainNameSchema, messageHashSchema } from './base'
-import { AddDomainTarget } from '../constants'
+import { EntityDomainType } from '../constants'
 
 // DOMAINS
 
 export const domainSchema = z.object({
   name: domainNameSchema,
   target: z.enum([
-    AddDomainTarget.IPFS,
-    AddDomainTarget.Program,
-    AddDomainTarget.Instance,
+    EntityDomainType.IPFS,
+    EntityDomainType.Program,
+    EntityDomainType.Instance,
   ]),
   ref: messageHashSchema,
 })

--- a/src/helpers/schemas/domain.ts
+++ b/src/helpers/schemas/domain.ts
@@ -11,7 +11,6 @@ export const domainSchema = z.object({
     AddDomainTarget.Program,
     AddDomainTarget.Instance,
   ]),
-  programType: programTypeSchema,
   ref: messageHashSchema,
 })
 

--- a/src/hooks/form/useAddDomains.ts
+++ b/src/hooks/form/useAddDomains.ts
@@ -12,14 +12,12 @@ export type DomainField = {
   name: string
   ref: string
   target: AddDomainTarget
-  programType: EntityType.Instance | EntityType.Program
 }
 
 export const defaultValues: DomainField = {
   name: '',
   ref: '',
   target: AddDomainTarget.Instance,
-  programType: EntityType.Instance,
 }
 
 export type UseDomainItemProps = {
@@ -77,7 +75,7 @@ export type UseDomainsReturn = {
 export function useAddDomains({
   name = 'domains',
   control,
-  entityType: programType,
+  entityType: target,
 }: UseDomainsProps): UseDomainsReturn {
   const domainsCtrl = useFieldArray({
     control,
@@ -87,8 +85,8 @@ export function useAddDomains({
   const { fields, remove: handleRemove, append } = domainsCtrl
 
   const handleAdd = useCallback(() => {
-    append({ ...defaultValues, programType })
-  }, [append, programType])
+    append({ ...defaultValues, target })
+  }, [append, target])
 
   return {
     name,

--- a/src/hooks/form/useAddDomains.ts
+++ b/src/hooks/form/useAddDomains.ts
@@ -1,4 +1,4 @@
-import { AddDomainTarget, EntityType } from '@/helpers/constants'
+import { EntityDomainType } from '@/helpers/constants'
 import { useCallback } from 'react'
 import {
   Control,
@@ -11,13 +11,13 @@ import {
 export type DomainField = {
   name: string
   ref: string
-  target: AddDomainTarget
+  target: EntityDomainType
 }
 
 export const defaultValues: DomainField = {
   name: '',
   ref: '',
-  target: AddDomainTarget.Instance,
+  target: EntityDomainType.Instance,
 }
 
 export type UseDomainItemProps = {
@@ -61,7 +61,7 @@ export function useDomainItem({
 export type UseDomainsProps = {
   name?: string
   control: Control
-  entityType: EntityType.Program | EntityType.Instance
+  entityType: EntityDomainType
 }
 
 export type UseDomainsReturn = {

--- a/src/hooks/pages/dashboard/useNewDomainPage.ts
+++ b/src/hooks/pages/dashboard/useNewDomainPage.ts
@@ -27,7 +27,7 @@ export const defaultValues: NewDomainFormState = {
 export type DomainRefOptions = {
   label: string
   value: string
-  type: EntityType
+  type: AddDomainTarget
 }
 
 export type UseNewDomainPageReturn = {
@@ -36,9 +36,8 @@ export type UseNewDomainPageReturn = {
   hasFunctions: boolean
   hasEntities: boolean
   nameCtrl: UseControllerReturn<NewDomainFormState, 'name'>
-  programTypeCtrl: UseControllerReturn<NewDomainFormState, 'programType'>
+  targetCtrl: UseControllerReturn<NewDomainFormState, 'target'>
   refCtrl: UseControllerReturn<NewDomainFormState, 'ref'>
-  ipfsRefCtrl: UseControllerReturn<NewDomainFormState, 'ref'>
   errors: FieldErrors<NewDomainFormState>
   handleSubmit: (e: FormEvent) => Promise<void>
 }
@@ -82,18 +81,12 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
     name: 'name',
   })
 
-  const programTypeCtrl = useController({
+  const targetCtrl = useController({
     control,
-    name: 'programType',
+    name: 'target',
     rules: {
       onChange(state) {
         setValue('ref', '')
-
-        if (state.target.value === EntityType.Program) {
-          setValue('target', AddDomainTarget.Program)
-        } else if (state.target.value === EntityType.Instance) {
-          setValue('target', AddDomainTarget.Instance)
-        }
       },
     },
   })
@@ -103,17 +96,7 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
     name: 'ref',
   })
 
-  const ipfsRefCtrl = useController({
-    control,
-    name: 'ref',
-    rules: {
-      onChange() {
-        setValue('target', AddDomainTarget.IPFS)
-      },
-    },
-  })
-
-  const entityType = programTypeCtrl.field.value
+  const entityType = targetCtrl.field.value
 
   const entities = useMemo(() => {
     const entities = !entityType
@@ -147,14 +130,19 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
   )
 
   useEffect(() => {
-    if (entityType === EntityType.Instance && !hasInstances) {
-      setValue('programType', EntityType.Program)
+    if (entityType === EntityType.Instance && hasInstances) {
+      setValue('target', EntityType.Instance)
     }
 
-    if (entityType === EntityType.Program && !hasFunctions) {
-      setValue('programType', EntityType.Instance)
+    if (entityType === EntityType.Program && hasFunctions) {
+      setValue('target', EntityType.Program)
     }
+
   }, [entityType, hasFunctions, hasInstances, setValue])
+
+  const setTarget = (target) => {
+    setValue('target', target)
+  }
 
   return {
     entities,
@@ -162,10 +150,10 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
     hasFunctions,
     hasEntities,
     nameCtrl,
-    programTypeCtrl,
+    targetCtrl,
     refCtrl,
-    ipfsRefCtrl,
     errors,
     handleSubmit,
+    setTarget
   }
 }

--- a/src/hooks/pages/dashboard/useNewDomainPage.ts
+++ b/src/hooks/pages/dashboard/useNewDomainPage.ts
@@ -6,7 +6,7 @@ import { useDomainManager } from '@/hooks/common/useManager/useDomainManager'
 import { useAppState } from '@/contexts/appState'
 import { ActionTypes } from '@/helpers/store'
 import { DomainManager } from '@/domain/domain'
-import { EntityType, AddDomainTarget } from '@/helpers/constants'
+import { EntityDomainType } from '@/helpers/constants'
 import {
   FieldErrors,
   UseControllerReturn,
@@ -27,7 +27,7 @@ export const defaultValues: NewDomainFormState = {
 export type DomainRefOptions = {
   label: string
   value: string
-  type: AddDomainTarget
+  type: EntityDomainType
 }
 
 export type UseNewDomainPageReturn = {
@@ -40,6 +40,7 @@ export type UseNewDomainPageReturn = {
   refCtrl: UseControllerReturn<NewDomainFormState, 'ref'>
   errors: FieldErrors<NewDomainFormState>
   handleSubmit: (e: FormEvent) => Promise<void>
+  setTarget: (target: EntityDomainType) => void
 }
 
 export function useNewDomainPage(): UseNewDomainPageReturn {
@@ -101,7 +102,7 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
   const entities = useMemo(() => {
     const entities = !entityType
       ? []
-      : entityType === EntityType.Instance
+      : entityType === EntityDomainType.Instance
       ? accountInstances
       : accountFunctions
 
@@ -130,16 +131,16 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
   )
 
   useEffect(() => {
-    if (entityType === EntityType.Instance && hasInstances) {
-      setValue('target', EntityType.Instance)
+    if (entityType === EntityDomainType.Instance && hasInstances) {
+      setValue('target', EntityDomainType.Instance)
     }
 
-    if (entityType === EntityType.Program && hasFunctions) {
-      setValue('target', EntityType.Program)
+    if (entityType === EntityDomainType.Program && hasFunctions) {
+      setValue('target', EntityDomainType.Program)
     }
   }, [entityType, hasFunctions, hasInstances, setValue])
 
-  const setTarget = (target) => {
+  const setTarget = (target: EntityDomainType) => {
     setValue('target', target)
   }
 

--- a/src/hooks/pages/dashboard/useNewDomainPage.ts
+++ b/src/hooks/pages/dashboard/useNewDomainPage.ts
@@ -137,7 +137,6 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
     if (entityType === EntityType.Program && hasFunctions) {
       setValue('target', EntityType.Program)
     }
-
   }, [entityType, hasFunctions, hasInstances, setValue])
 
   const setTarget = (target) => {
@@ -154,6 +153,6 @@ export function useNewDomainPage(): UseNewDomainPageReturn {
     refCtrl,
     errors,
     handleSubmit,
-    setTarget
+    setTarget,
   }
 }


### PR DESCRIPTION
The structure of the domain aggregate for program message (instance or function) is not implemented right. This fixes replaces `ipfs` with the program type value, when linking a domain to a program.

```diff
{
-   "type": "ipfs",
+   "type": "program",
    "message_id": <item_hash>,
    updated_at: <ISO timestamp>
    [programType]: "FUNCTION" | "INSTANCE"
}
```

fixes #77 

---

:warning: This is a hotfix, there is probably a better way to handle this