### PR TITLE
Fix: Switching network inconsistencies

### DIFF
--- a/src/hooks/common/useConnect.ts
+++ b/src/hooks/common/useConnect.ts
@@ -66,8 +66,6 @@ export function useConnect(): UseConnectReturn {
         setSelectedNetwork(chain)
       } catch (err) {
         const e = err as Error
-        //@ts-ignore | to-do: handle error: Request of type 'wallet_addEthereumChain' already pending for origin http://localhost:3000. Please wait.
-        //if (err.code === -32002) return;
         onError(e.message) // we assume because the user denied the connection
       }
       if (!account) return

--- a/src/hooks/pages/useHeader.ts
+++ b/src/hooks/pages/useHeader.ts
@@ -189,15 +189,6 @@ export function useHeader(): UseHeaderReturn {
     [connect, disconnect, isConnected, router, setkeepAccountAlive],
   )
 
-  useEffect(() => {
-    ;(async () => {
-      if (!account && keepAccountAlive) {
-        enableConnection()
-      }
-    })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [account, keepAccountAlive])
-
   // --------------------
 
   const provider = () => {


### PR DESCRIPTION
The issue was related to how the connect function handled error cases. Previously, all errors were assumed to be network switching cases, but the caught error was actually due to multiple calls to this function (not yet resolved, with the specific error 'wallet_addEthereumChain already pending'). For now, this error is being bypassed.

![image](https://github.com/aleph-im/front-aleph-cloud-page/assets/32191898/4b94a1fd-d030-40db-a492-55bc1263d877)

Changes:

Moved the network switching functionality into a specific function, rather than handling it in the connect function's catch block.

Related:

It's unclear to me how the WalletPicker component shares the state of the selected network with the app. It seems that this state is isolated. [WalletPicker Component](https://github.com/aleph-im/front-core/blob/main/src/components/modules/WalletPicker/cmp.tsx)
The handleConnect function is called without a network argument, leading to an undefined state at the end of the call tree. [handleConnect Function](https://github.com/aleph-im/front-aleph-cloud-page/blob/main/src/components/common/Header/cmp.tsx#L87)



