### PR TITLE
fix: update balances when switching networks

### DIFF
--- a/src/hooks/common/useConnect.ts
+++ b/src/hooks/common/useConnect.ts
@@ -92,6 +92,7 @@ export function useConnect(): UseConnectReturn {
       try {
         account = await web3Connect(chain, window.ethereum)
         setSelectedNetwork(chain)
+        getBalance(account)
         console.log('Account connected after switching network: ', account)
       } catch (err) {
         const e = err as Error

--- a/src/hooks/common/useConnect.ts
+++ b/src/hooks/common/useConnect.ts
@@ -92,7 +92,10 @@ export function useConnect(): UseConnectReturn {
       try {
         account = await web3Connect(chain, window.ethereum)
         setSelectedNetwork(chain)
-        getBalance(account)
+        await Promise.all([getBalance(account)]).catch((err) => {
+          onError(err.message)
+        })
+
         console.log('Account connected after switching network: ', account)
       } catch (err) {
         const e = err as Error


### PR DESCRIPTION
I noticed that in the connection function Promise.all was used, to maybe in the future allow multiple wallet connections in the app, so multiple balances to fetch