### PR TITLE
Fix: README.md did not explain fontawesome auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Aleph Cloud Solutions is a [next.js](https://nextjs.org/) frontend dApp that all
 
 ## Develop locally
 
+First obtain an authentication token to access the proprietary Font Awesome icons and edit `.npmrc` to 
+include the aforementioned token.
+
 After cloning the repo make sure to install NPM dependency by running `npm i`
 
 To run the project in development mode (`http://localhost:3000`)


### PR DESCRIPTION
Problem: Running `npm i` on a fresh repository fails due to a missing authentication token for the proprietary Font Awesome icon font.

This documents that fact instead of solving the core issue.
