### PR TITLE
Fix: `npm dev` exfiltrated private data to NextJS telemetry

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@
 
 # The "create function/volume" button won't be disabled in the UI even if you have insufficient balance
 NEXT_PUBLIC_OVERRIDE_ALEPH_BALANCE=false
+NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
Solution: Disable the NextJS telemetry by default using an environment variable.
