### PR TITLE
Fix: broken update website

### DIFF
--- a/src/components/pages/dashboard/ManageWebsite/cmp.tsx
+++ b/src/components/pages/dashboard/ManageWebsite/cmp.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useEffect } from 'react'
 import Link from 'next/link'
 import {
   Label,
@@ -127,6 +127,13 @@ export function ManageWebsite() {
     handleCopyUrl,
     handleCopyVolumeHash,
   } = useManageWebsite()
+
+  const cid = state.values.website?.cid
+  useEffect(() => {
+    if (!cid) return
+    handleUpdate(cid as string)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cid])
 
   if (!website || !cidV1) {
     return (

--- a/src/hooks/pages/solutions/manage/useManageWebsite.ts
+++ b/src/hooks/pages/solutions/manage/useManageWebsite.ts
@@ -158,13 +158,6 @@ export function useManageWebsite(): ManageWebsite {
 
   const state = useNewWebsitePage()
   const theme = useTheme()
-  const cid = state.values.website?.cid
-
-  useEffect(() => {
-    if (!cid) return
-    handleUpdate(cid as string)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cid, handleUpdate])
 
   return {
     website,


### PR DESCRIPTION
When trying to update a website, re-rendering gets crazy and starts spamming signature requests.
=> temporary revert