### PR TITLE
Feat: Confidential Instances (Beta) pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "front-aleph-cloud",
       "version": "0.14.3",
       "dependencies": {
-        "@aleph-front/core": "^1.22.3",
+        "@aleph-front/core": "^1.23.0",
         "@aleph-sdk/account": "^1.0.3",
         "@aleph-sdk/avalanche": "^1.0.3",
         "@aleph-sdk/client": "^1.0.6",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@aleph-front/core": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@aleph-front/core/-/core-1.22.3.tgz",
-      "integrity": "sha512-I2fZOi17fWLa5ZCB5Ed1oNSUl6mdmePmiT78w1LzmC+Zz1PHX3JyFHY8jmHKdejbFGP8tzn+JmZPcf/WOVwUgg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@aleph-front/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-PnUDIK/KxuOqqY7cnFBhJup9lukfVAumAw7qB8bDUWiZ6jefKDUQ/9ahX8hIPcZT0RBLnqhYS0si65RjFe1bmg==",
       "dependencies": {
         "@monaco-editor/react": "^4.4.6",
         "react-infinite-scroll-hook": "^4.1.1",
@@ -19652,9 +19652,9 @@
   },
   "dependencies": {
     "@aleph-front/core": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@aleph-front/core/-/core-1.22.3.tgz",
-      "integrity": "sha512-I2fZOi17fWLa5ZCB5Ed1oNSUl6mdmePmiT78w1LzmC+Zz1PHX3JyFHY8jmHKdejbFGP8tzn+JmZPcf/WOVwUgg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@aleph-front/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-PnUDIK/KxuOqqY7cnFBhJup9lukfVAumAw7qB8bDUWiZ6jefKDUQ/9ahX8hIPcZT0RBLnqhYS0si65RjFe1bmg==",
       "requires": {
         "@monaco-editor/react": "^4.4.6",
         "react-infinite-scroll-hook": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "next lint --fix"
   },
   "dependencies": {
-    "@aleph-front/core": "^1.22.3",
+    "@aleph-front/core": "^1.23.0",
     "@aleph-sdk/account": "^1.0.3",
     "@aleph-sdk/avalanche": "^1.0.3",
     "@aleph-sdk/client": "^1.0.6",

--- a/src/components/common/DashboardCardWithSideImage/cmp.tsx
+++ b/src/components/common/DashboardCardWithSideImage/cmp.tsx
@@ -36,7 +36,7 @@ export const DashboardCardWithSideImage = ({
           </div>
           {(withButton || externalLinkUrl) && (
             <div tw="mt-6 flex flex-wrap items-center justify-between gap-6">
-              {withButton && (
+              {withButton && buttonUrl && buttonText && (
                 <ButtonLink variant="primary" size="md" href={buttonUrl}>
                   {buttonText}
                 </ButtonLink>

--- a/src/components/common/DashboardCardWithSideImage/types.ts
+++ b/src/components/common/DashboardCardWithSideImage/types.ts
@@ -5,7 +5,7 @@ export type DashboardCardWithSideImageProps = {
   imageSrc: string
   imageAlt: string
   withButton?: boolean
-  buttonUrl: string
-  buttonText: string
+  buttonUrl?: string
+  buttonText?: string
   externalLinkUrl?: string
 }

--- a/src/components/common/EntityCard/cmp.tsx
+++ b/src/components/common/EntityCard/cmp.tsx
@@ -51,6 +51,7 @@ export const EntityCard = ({
   img,
   dashboardPath = '#',
   createPath = '#',
+  createTarget = '_self',
   introductionButtonText,
   subItems = [],
   information,
@@ -151,13 +152,25 @@ export const EntityCard = ({
       case 'introduction':
         return (
           <div tw="mt-auto">
-            <ButtonLink variant="textOnly" size="sm" href={createPath}>
+            <ButtonLink
+              variant="textOnly"
+              size="sm"
+              href={createPath}
+              target={createTarget}
+            >
               <Icon name="plus-circle" /> {introductionButtonText}
             </ButtonLink>
           </div>
         )
     }
-  }, [createPath, dashboardPath, information, introductionButtonText, type])
+  }, [
+    createPath,
+    createTarget,
+    dashboardPath,
+    information,
+    introductionButtonText,
+    type,
+  ])
 
   return (
     <div tw="flex">

--- a/src/components/common/EntityCard/types.ts
+++ b/src/components/common/EntityCard/types.ts
@@ -1,3 +1,4 @@
+import { HTMLAttributeAnchorTarget } from 'react'
 import { AmountInformationProps } from '../AmountInformation/types'
 import { ComputingInformationProps } from '../ComputingInformation/types'
 import { StorageInformationProps } from '../StorageInformation/types'
@@ -28,6 +29,7 @@ export type EntityCardProps = {
   description?: string
   dashboardPath?: string
   createPath?: string
+  createTarget?: HTMLAttributeAnchorTarget
   introductionButtonText?: string
   information: InformationProps
   storage?: number

--- a/src/components/common/Header/cmp.tsx
+++ b/src/components/common/Header/cmp.tsx
@@ -24,6 +24,7 @@ export const Header = () => {
     networks,
     accountAddress,
     accountBalance,
+    accountVouchers,
     rewards,
     selectedNetwork,
     handleToggle,
@@ -51,6 +52,7 @@ export const Header = () => {
                 isMobile
                 accountAddress={accountAddress}
                 accountBalance={accountBalance}
+                accountVouchers={accountVouchers}
                 blockchains={blockchains}
                 networks={networks}
                 selectedNetwork={selectedNetwork}
@@ -70,6 +72,7 @@ export const Header = () => {
           <AccountPicker
             accountAddress={accountAddress}
             accountBalance={accountBalance}
+            accountVouchers={accountVouchers}
             blockchains={blockchains}
             networks={networks}
             selectedNetwork={selectedNetwork}

--- a/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
+++ b/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Tabs } from '@aleph-front/core'
 import Container from '@/components/common/CenteredContainer'
 import HoldTokenDisclaimer from '@/components/common/HoldTokenDisclaimer'
@@ -9,8 +9,22 @@ import { useConfidentialDashboardPage } from '@/hooks/pages/computing/useConfide
 import InstancesTabContent from '../../dashboard/InstancesTabContent'
 
 export default function ConfidentialDashboardPage() {
-  const { tabs, tabId, setTabId, confidentials, volumes, domains } =
-    useConfidentialDashboardPage()
+  const {
+    authorized,
+    onUnauthorized,
+    tabs,
+    tabId,
+    setTabId,
+    confidentials,
+    volumes,
+    domains,
+  } = useConfidentialDashboardPage()
+
+  useEffect(() => {
+    if (!authorized) onUnauthorized()
+  }, [authorized, onUnauthorized])
+
+  if (!authorized) return
 
   return (
     <>

--- a/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
+++ b/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Tabs } from '@aleph-front/core'
+import Container from '@/components/common/CenteredContainer'
+import HoldTokenDisclaimer from '@/components/common/HoldTokenDisclaimer'
+import VolumesTabContent from '../../dashboard/VolumesTabContent'
+import DomainsTabContent from '../../dashboard/DomainsTabContent'
+import DashboardCardWithSideImage from '@/components/common/DashboardCardWithSideImage'
+import { useConfidentialDashboardPage } from '@/hooks/pages/computing/useConfidentialDashboardPage'
+import InstancesTabContent from '../../dashboard/InstancesTabContent'
+
+export default function ConfidentialDashboardPage() {
+  const { tabs, tabId, setTabId, confidentials, volumes, domains } =
+    useConfidentialDashboardPage()
+
+  return (
+    <>
+      <Container $variant="xl" tw="my-10">
+        <Tabs selected={tabId} tabs={tabs} onTabChange={setTabId} />
+      </Container>
+      <div role="tabpanel">
+        {tabId === 'confidential' ? (
+          <>
+            {!!confidentials.length && (
+              <Container $variant="xl" tw="my-10">
+                <InstancesTabContent data={confidentials} />
+              </Container>
+            )}
+            <DashboardCardWithSideImage
+              imageSrc="/img/dashboard/confidential.svg"
+              imageAlt="Confidential illustration"
+              info="WHAT IS A..."
+              title="Confidential VM"
+              description="[PENDING]"
+              withButton={false}
+            />
+          </>
+        ) : tabId === 'volume' ? (
+          <>
+            {!!volumes.length && (
+              <Container $variant="xl" tw="my-10">
+                <VolumesTabContent data={volumes} cta={false} />
+              </Container>
+            )}
+          </>
+        ) : tabId === 'domain' ? (
+          <>
+            {!!domains.length && (
+              <Container $variant="xl" tw="my-10">
+                <DomainsTabContent data={domains} cta={false} />
+              </Container>
+            )}
+          </>
+        ) : (
+          <></>
+        )}
+      </div>
+      <Container $variant="xl">
+        <HoldTokenDisclaimer />
+      </Container>
+    </>
+  )
+}

--- a/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
+++ b/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
@@ -6,12 +6,12 @@ import VolumesTabContent from '../../dashboard/VolumesTabContent'
 import DomainsTabContent from '../../dashboard/DomainsTabContent'
 import DashboardCardWithSideImage from '@/components/common/DashboardCardWithSideImage'
 import { useConfidentialDashboardPage } from '@/hooks/pages/computing/useConfidentialDashboardPage'
-import InstancesTabContent from '../../dashboard/InstancesTabContent'
+import ConfidentialsTabContent from '../../dashboard/ConfidentialsTabContent'
 
 export default function ConfidentialDashboardPage() {
   const {
     authorized,
-    onUnauthorized,
+    handleUnauthorized,
     tabs,
     tabId,
     setTabId,
@@ -21,8 +21,8 @@ export default function ConfidentialDashboardPage() {
   } = useConfidentialDashboardPage()
 
   useEffect(() => {
-    if (!authorized) onUnauthorized()
-  }, [authorized, onUnauthorized])
+    if (!authorized) handleUnauthorized()
+  }, [authorized, handleUnauthorized])
 
   if (!authorized) return
 
@@ -36,15 +36,15 @@ export default function ConfidentialDashboardPage() {
           <>
             {!!confidentials.length && (
               <Container $variant="xl" tw="my-10">
-                <InstancesTabContent data={confidentials} />
+                <ConfidentialsTabContent data={confidentials} />
               </Container>
             )}
             <DashboardCardWithSideImage
-              imageSrc="/img/dashboard/confidential.svg"
+              imageSrc="/img/dashboard/instance.svg"
               imageAlt="Confidential illustration"
               info="WHAT IS A..."
-              title="Confidential VM"
-              description="[PENDING]"
+              title="Confidential Instance"
+              description="Protect your sensitive workloads with our Confidential VMs. Designed for maximum privacy and security, ensuring your execution and data stays safe."
               withButton={false}
             />
           </>

--- a/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
+++ b/src/components/pages/computing/ConfidentialDashboardPage/cmp.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from 'react'
 import { Tabs } from '@aleph-front/core'
 import Container from '@/components/common/CenteredContainer'
 import HoldTokenDisclaimer from '@/components/common/HoldTokenDisclaimer'
@@ -9,20 +8,8 @@ import { useConfidentialDashboardPage } from '@/hooks/pages/computing/useConfide
 import ConfidentialsTabContent from '../../dashboard/ConfidentialsTabContent'
 
 export default function ConfidentialDashboardPage() {
-  const {
-    authorized,
-    handleUnauthorized,
-    tabs,
-    tabId,
-    setTabId,
-    confidentials,
-    volumes,
-    domains,
-  } = useConfidentialDashboardPage()
-
-  useEffect(() => {
-    if (!authorized) handleUnauthorized()
-  }, [authorized, handleUnauthorized])
+  const { authorized, tabs, tabId, setTabId, confidentials, volumes, domains } =
+    useConfidentialDashboardPage()
 
   if (!authorized) return
 

--- a/src/components/pages/computing/ConfidentialDashboardPage/index.ts
+++ b/src/components/pages/computing/ConfidentialDashboardPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/dashboard/ConfidentialsTabContent/cmp.tsx
+++ b/src/components/pages/dashboard/ConfidentialsTabContent/cmp.tsx
@@ -1,0 +1,123 @@
+import React, { memo } from 'react'
+import tw from 'twin.macro'
+import { ConfidentialsTabContentProps } from './types'
+import ButtonLink from '@/components/common/ButtonLink'
+import {
+  convertByteUnits,
+  ellipseAddress,
+  humanReadableSize,
+} from '@/helpers/utils'
+import EntityTable from '@/components/common/EntityTable'
+import { Icon, NoisyContainer } from '@aleph-front/core'
+
+const CreateConfidentialButton = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => (
+  <ButtonLink
+    variant="primary"
+    href="https://docs.aleph.im/computing/confidential/"
+    target="_blank"
+  >
+    {children}
+  </ButtonLink>
+)
+CreateConfidentialButton.displayName = 'CreateConfidentialButton'
+
+export const ConfidentialsTabContent = memo(
+  ({ data }: ConfidentialsTabContentProps) => {
+    return (
+      <>
+        {data.length > 0 ? (
+          <>
+            <NoisyContainer>
+              <div tw="overflow-auto max-w-full">
+                <EntityTable
+                  borderType="none"
+                  rowNoise
+                  rowKey={(row) => row.id}
+                  data={data}
+                  columns={[
+                    {
+                      label: 'Name',
+                      width: '100%',
+                      sortable: true,
+                      render: (row) =>
+                        (row?.metadata?.name as string) ||
+                        ellipseAddress(row.id),
+                    },
+                    {
+                      label: 'Cores',
+                      align: 'right',
+                      sortable: true,
+                      render: (row) => row?.resources?.vcpus || 0,
+                    },
+                    {
+                      label: 'RAM',
+                      align: 'right',
+                      sortable: true,
+                      render: (row) =>
+                        convertByteUnits(row?.resources?.memory || 0, {
+                          from: 'MiB',
+                          to: 'GiB',
+                          displayUnit: true,
+                        }),
+                    },
+                    {
+                      label: 'HDD',
+                      align: 'right',
+                      sortable: true,
+                      render: (row) => humanReadableSize(row.size, 'MiB'),
+                    },
+                    {
+                      label: 'Date',
+                      align: 'right',
+                      sortable: true,
+                      render: (row) => row.date,
+                    },
+                    {
+                      label: '',
+                      align: 'right',
+                      render: (row) => (
+                        <ButtonLink
+                          kind="functional"
+                          variant="secondary"
+                          href={`/computing/confidential/${row.id}`}
+                        >
+                          <Icon name="angle-right" size="lg" />
+                        </ButtonLink>
+                      ),
+                      cellProps: () => ({
+                        css: tw`pl-3!`,
+                      }),
+                    },
+                  ]}
+                />
+              </div>
+            </NoisyContainer>
+
+            <div tw="mt-20 text-center">
+              <CreateConfidentialButtonMemo>
+                Create confidential instance
+              </CreateConfidentialButtonMemo>
+            </div>
+          </>
+        ) : (
+          <div tw="mt-10 text-center">
+            <CreateConfidentialButtonMemo>
+              Create your first confidential instance
+            </CreateConfidentialButtonMemo>
+          </div>
+        )}
+      </>
+    )
+  },
+)
+ConfidentialsTabContent.displayName = 'ConfidentialsTabContent'
+
+const CreateConfidentialButtonMemo = memo(
+  CreateConfidentialButton,
+) as typeof CreateConfidentialButton
+
+export default ConfidentialsTabContent

--- a/src/components/pages/dashboard/ConfidentialsTabContent/index.ts
+++ b/src/components/pages/dashboard/ConfidentialsTabContent/index.ts
@@ -1,0 +1,2 @@
+export { default } from './cmp'
+export type { ConfidentialsTabContentProps } from './types'

--- a/src/components/pages/dashboard/ConfidentialsTabContent/types.ts
+++ b/src/components/pages/dashboard/ConfidentialsTabContent/types.ts
@@ -1,0 +1,5 @@
+import { Confidential } from '@/domain/confidential'
+
+export type ConfidentialsTabContentProps = {
+  data: Confidential[]
+}

--- a/src/components/pages/dashboard/DashboardPage/cmp.tsx
+++ b/src/components/pages/dashboard/DashboardPage/cmp.tsx
@@ -16,6 +16,7 @@ export default function DashboardPage() {
   const {
     instanceAggregatedStatus,
     programAggregatedStatus,
+    confidentialsAggregatedStatus,
     volumesAggregatedStatus,
     websitesAggregatedStatus,
     confidentialsAuthz,
@@ -151,7 +152,7 @@ export default function DashboardPage() {
                     ? 'active'
                     : 'introduction'
                 }
-                title="instance"
+                title="instances"
                 img="Object11"
                 description="Launch and manage virtual private servers (VPS) tailored to your needs. Choose automatic or manual node selection for complete control over your computing environment."
                 introductionButtonText="Create your instance"
@@ -165,16 +166,22 @@ export default function DashboardPage() {
             </EntityCardWrapper>
             <EntityCardWrapper>
               <EntityCard
-                type={'introduction'}
+                type={
+                  confidentialsAggregatedStatus.total.amount
+                    ? 'active'
+                    : 'introduction'
+                }
                 isComingSoon={!confidentialsAuthz}
                 title="confidentials"
                 img="Object9"
+                dashboardPath="/computing/confidential"
                 createPath="https://docs.aleph.im/computing/confidential/"
                 createTarget="_blank"
                 description="Protect your sensitive workloads with our Confidential VMs. Designed for maximum privacy and security, ensuring your data stays safe."
                 introductionButtonText="Create your confidential"
                 information={{
                   type: 'computing',
+                  data: confidentialsAggregatedStatus.total,
                 }}
               />
             </EntityCardWrapper>

--- a/src/components/pages/dashboard/DashboardPage/cmp.tsx
+++ b/src/components/pages/dashboard/DashboardPage/cmp.tsx
@@ -18,6 +18,7 @@ export default function DashboardPage() {
     programAggregatedStatus,
     volumesAggregatedStatus,
     websitesAggregatedStatus,
+    confidentialsAuthz,
   } = useDashboardPage()
 
   const programsCardItems = useMemo(() => {
@@ -165,7 +166,7 @@ export default function DashboardPage() {
             <EntityCardWrapper>
               <EntityCard
                 type={'introduction'}
-                isComingSoon
+                isComingSoon={!confidentialsAuthz}
                 title="confidentials"
                 img="Object9"
                 createPath="https://docs.aleph.im/computing/confidential/"

--- a/src/components/pages/dashboard/DashboardPage/cmp.tsx
+++ b/src/components/pages/dashboard/DashboardPage/cmp.tsx
@@ -168,6 +168,8 @@ export default function DashboardPage() {
                 isComingSoon
                 title="confidentials"
                 img="Object9"
+                createPath="https://docs.aleph.im/computing/confidential/"
+                createTarget="_blank"
                 description="Protect your sensitive workloads with our Confidential VMs. Designed for maximum privacy and security, ensuring your data stays safe."
                 introductionButtonText="Create your confidential"
                 information={{

--- a/src/components/pages/dashboard/ManageConfidential/cmp.tsx
+++ b/src/components/pages/dashboard/ManageConfidential/cmp.tsx
@@ -1,0 +1,282 @@
+import ButtonLink from '@/components/common/ButtonLink'
+import IconText from '@/components/common/IconText'
+import { Label, NoisyContainer } from '@aleph-front/core'
+import { EntityTypeName } from '@/helpers/constants'
+import { Icon, Tag, TextGradient } from '@aleph-front/core'
+import { convertByteUnits, ellipseAddress, ellipseText } from '@/helpers/utils'
+import { Container, Text, Separator } from '../common'
+import VolumeList from '../VolumeList'
+import { RotatingLines, ThreeDots } from 'react-loader-spinner'
+import { useTheme } from 'styled-components'
+import Link from 'next/link'
+import BackButtonSection from '@/components/common/BackButtonSection'
+import { useManageConfidential } from '@/hooks/pages/solutions/manage/useManageConfidential'
+import { useEffect } from 'react'
+
+export default function ManageConfidential() {
+  const {
+    authorized,
+    confidential,
+    status,
+    mappedKeys,
+    nodeDetails,
+    handleCopyHash,
+    handleCopyConnect,
+    handleCopyIpv6,
+    handleBack,
+    handleUnauthorized,
+  } = useManageConfidential()
+
+  const theme = useTheme()
+
+  useEffect(() => {
+    if (!authorized) handleUnauthorized()
+  }, [authorized, handleUnauthorized])
+
+  if (!authorized) return
+
+  if (!confidential) {
+    return (
+      <>
+        <BackButtonSection handleBack={handleBack} />
+        <Container>
+          <NoisyContainer tw="my-4">Loading...</NoisyContainer>
+        </Container>
+      </>
+    )
+  }
+
+  const name =
+    (confidential?.metadata?.name as string) || ellipseAddress(confidential.id)
+  const typeName = EntityTypeName[confidential.type]
+  const volumes = confidential.volumes
+
+  return (
+    <>
+      <BackButtonSection handleBack={handleBack} />
+      <section tw="px-0 pt-20 pb-6 md:py-10">
+        <Container>
+          <div tw="flex justify-between pb-5 flex-wrap gap-4 flex-col md:flex-row">
+            <div tw="flex items-center">
+              <Icon name="alien-8bit" tw="mr-4" className="text-main0" />
+              <div className="tp-body2">{name}</div>
+              <Label
+                kind="secondary"
+                variant={
+                  confidential.time < Date.now() - 1000 * 45 && status?.vm_ipv6
+                    ? 'success'
+                    : 'warning'
+                }
+                tw="ml-4"
+              >
+                {status?.vm_ipv6 ? (
+                  'READY'
+                ) : (
+                  <div tw="flex items-center">
+                    <div tw="mr-2">CONFIRMING</div>
+                    <RotatingLines
+                      strokeColor={theme.color.base2}
+                      width=".8rem"
+                    />
+                  </div>
+                )}
+              </Label>
+            </div>
+          </div>
+
+          <NoisyContainer>
+            <div tw="flex items-center justify-start overflow-hidden">
+              <Tag variant="accent" tw="mr-4 whitespace-nowrap">
+                {typeName}
+              </Tag>
+              <div tw="flex-auto">
+                <div className="tp-info text-main0">ITEM HASH</div>
+                <IconText iconName="copy" onClick={handleCopyHash}>
+                  {confidential.id}
+                </IconText>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div tw="flex my-5">
+              <div tw="mr-5">
+                <div className="tp-info text-main0">CORES</div>
+                <div>
+                  <Text>{confidential.resources.vcpus} x86 64bit</Text>
+                </div>
+              </div>
+
+              <div tw="mr-5">
+                <div className="tp-info text-main0">RAM</div>
+                <div>
+                  <Text>
+                    {convertByteUnits(confidential.resources.memory, {
+                      from: 'MiB',
+                      to: 'GiB',
+                      displayUnit: true,
+                    })}
+                  </Text>
+                </div>
+              </div>
+
+              <div tw="mr-5">
+                <div className="tp-info text-main0">HDD</div>
+                <div>
+                  <Text>
+                    {convertByteUnits(confidential.size, {
+                      from: 'MiB',
+                      to: 'GiB',
+                      displayUnit: true,
+                    })}
+                  </Text>
+                </div>
+              </div>
+            </div>
+
+            <div tw="mr-5">
+              <div className="tp-info text-main0">EXPLORER</div>
+              <div>
+                <a
+                  className="tp-body1 fs-16"
+                  href={confidential.url}
+                  target="_blank"
+                  referrerPolicy="no-referrer"
+                >
+                  <IconText iconName="square-up-right">
+                    <Text>{ellipseText(confidential.url, 80)}</Text>
+                  </IconText>
+                </a>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div tw="my-5">
+              <TextGradient type="h7" as="h2" color="main0">
+                Connection methods
+              </TextGradient>
+
+              <div tw="my-5">
+                <div className="tp-info text-main0">SSH COMMAND</div>
+                <div>
+                  {status ? (
+                    <IconText iconName="copy" onClick={handleCopyConnect}>
+                      <Text>&gt;_ ssh root@{status.vm_ipv6}</Text>
+                    </IconText>
+                  ) : (
+                    <div tw="flex items-end">
+                      <span tw="mr-1" className="tp-body1 fs-16 text-main2">
+                        Allocating
+                      </span>
+                      <ThreeDots
+                        width=".8rem"
+                        height="1rem"
+                        color={theme.color.main2}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div tw="my-5">
+                <div className="tp-info text-main0">IPv6</div>
+                <div>
+                  {status && (
+                    <IconText iconName="copy" onClick={handleCopyIpv6}>
+                      <Text>{status.vm_ipv6}</Text>
+                    </IconText>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div tw="my-5">
+              <TextGradient type="h7" as="h2" color="main0">
+                Accessible for
+              </TextGradient>
+
+              <div tw="my-5 flex">
+                {mappedKeys.map(
+                  (key, i) =>
+                    key && (
+                      <div key={key?.id} tw="mr-5">
+                        <div className="tp-info text-main0">
+                          SSH KEY #{i + 1}
+                        </div>
+
+                        <Link
+                          className="tp-body1 fs-16"
+                          href={'?hash=' + key.id}
+                          referrerPolicy="no-referrer"
+                        >
+                          <IconText iconName="square-up-right">
+                            <Text>{key.label}</Text>
+                          </IconText>
+                        </Link>
+                      </div>
+                    ),
+                )}
+              </div>
+            </div>
+
+            {nodeDetails && (
+              <>
+                <Separator />
+
+                <TextGradient type="h7" as="h2" color="main0">
+                  Current CRN
+                </TextGradient>
+
+                <div tw="my-5">
+                  <div className="tp-info text-main0">NAME</div>
+                  <div>
+                    <Text>{nodeDetails.name}</Text>
+                  </div>
+                </div>
+
+                <div tw="my-5">
+                  <div className="tp-info text-main0">URL</div>
+                  <div>
+                    <a
+                      className="tp-body1 fs-16"
+                      href={nodeDetails.url}
+                      target="_blank"
+                      referrerPolicy="no-referrer"
+                    >
+                      <IconText iconName="square-up-right">
+                        <Text>{ellipseText(nodeDetails.url, 80)}</Text>
+                      </IconText>
+                    </a>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {volumes.length > 0 && (
+              <>
+                <Separator />
+
+                <TextGradient type="h7" as="h2" color="main0">
+                  Linked Storage(s)
+                </TextGradient>
+
+                <VolumeList {...{ volumes }} />
+              </>
+            )}
+          </NoisyContainer>
+
+          <div tw="mt-20 text-center">
+            <ButtonLink
+              variant="primary"
+              href="https://docs.aleph.im/computing/confidential/"
+              target="_blank"
+            >
+              Create new confidential instance
+            </ButtonLink>
+          </div>
+        </Container>
+      </section>
+    </>
+  )
+}

--- a/src/components/pages/dashboard/ManageConfidential/cmp.tsx
+++ b/src/components/pages/dashboard/ManageConfidential/cmp.tsx
@@ -7,15 +7,14 @@ import { convertByteUnits, ellipseAddress, ellipseText } from '@/helpers/utils'
 import { Container, Text, Separator } from '../common'
 import VolumeList from '../VolumeList'
 import { RotatingLines, ThreeDots } from 'react-loader-spinner'
-import { useTheme } from 'styled-components'
 import Link from 'next/link'
 import BackButtonSection from '@/components/common/BackButtonSection'
 import { useManageConfidential } from '@/hooks/pages/solutions/manage/useManageConfidential'
-import { useEffect } from 'react'
 
 export default function ManageConfidential() {
   const {
     authorized,
+    theme,
     confidential,
     status,
     mappedKeys,
@@ -24,14 +23,7 @@ export default function ManageConfidential() {
     handleCopyConnect,
     handleCopyIpv6,
     handleBack,
-    handleUnauthorized,
   } = useManageConfidential()
-
-  const theme = useTheme()
-
-  useEffect(() => {
-    if (!authorized) handleUnauthorized()
-  }, [authorized, handleUnauthorized])
 
   if (!authorized) return
 

--- a/src/components/pages/dashboard/ManageConfidential/index.ts
+++ b/src/components/pages/dashboard/ManageConfidential/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/domain/confidential.ts
+++ b/src/domain/confidential.ts
@@ -2,7 +2,7 @@ import { Account } from '@aleph-sdk/account'
 import { InstanceContent, MessageType } from '@aleph-sdk/message'
 import { defaultInstanceChannel, EntityType } from '@/helpers/constants'
 import { getDate, getExplorerURL } from '@/helpers/utils'
-import { ExecutableManager } from './executable'
+import { ExecutableManager, ExecutableStatus } from './executable'
 import { FileManager } from './file'
 import { SSHKeyManager } from './ssh'
 import { VolumeManager } from './volume'
@@ -17,6 +17,8 @@ import {
   AlephHttpClient,
   AuthenticatedAlephHttpClient,
 } from '@aleph-sdk/client'
+
+export type ConfidentialStatus = ExecutableStatus | undefined
 
 // @todo: Refactor
 export type Confidential = InstanceContent & {
@@ -75,7 +77,7 @@ export class ConfidentialManager
         if (content === undefined) return false
 
         // Filter out normal instances (non-confidential VMs)
-        return content.environment?.trusted_execution?.firmware
+        return content.environment?.trusted_execution
       })
       .map((message) => {
         return {

--- a/src/domain/confidential.ts
+++ b/src/domain/confidential.ts
@@ -1,0 +1,94 @@
+import { Account } from '@aleph-sdk/account'
+import { InstanceContent, MessageType } from '@aleph-sdk/message'
+import { defaultInstanceChannel, EntityType } from '@/helpers/constants'
+import { getDate, getExplorerURL } from '@/helpers/utils'
+import { ExecutableManager } from './executable'
+import { FileManager } from './file'
+import { SSHKeyManager } from './ssh'
+import { VolumeManager } from './volume'
+import { DomainManager } from './domain'
+import { ReadOnlyEntityManager } from './types'
+import {
+  instanceSchema,
+  instanceStreamSchema,
+} from '@/helpers/schemas/instance'
+import { NodeManager } from './node'
+import {
+  AlephHttpClient,
+  AuthenticatedAlephHttpClient,
+} from '@aleph-sdk/client'
+
+// @todo: Refactor
+export type Confidential = InstanceContent & {
+  type: EntityType.Instance
+  id: string // hash
+  name: string
+  url: string
+  date: string
+  size: number
+  confirmed?: boolean
+}
+
+export class ConfidentialManager
+  extends ExecutableManager
+  implements ReadOnlyEntityManager<Confidential>
+{
+  static addSchema = instanceSchema
+  static addStreamSchema = instanceStreamSchema
+
+  constructor(
+    protected account: Account,
+    protected sdkClient: AlephHttpClient | AuthenticatedAlephHttpClient,
+    protected volumeManager: VolumeManager,
+    protected domainManager: DomainManager,
+    protected sshKeyManager: SSHKeyManager,
+    protected fileManager: FileManager,
+    protected nodeManager: NodeManager,
+    protected channel = defaultInstanceChannel,
+  ) {
+    super(account, volumeManager, domainManager, nodeManager, sdkClient)
+  }
+
+  async getAll(): Promise<Confidential[]> {
+    try {
+      const response = await this.sdkClient.getMessages({
+        addresses: [this.account.address],
+        messageTypes: [MessageType.instance],
+        channels: [this.channel],
+      })
+
+      return await this.parseMessages(response.messages)
+    } catch (err) {
+      return []
+    }
+  }
+
+  async get(id: string): Promise<Confidential | undefined> {
+    const message = await this.sdkClient.getMessage(id)
+
+    const [entity] = await this.parseMessages([message])
+    return entity
+  }
+
+  protected async parseMessages(messages: any[]): Promise<Confidential[]> {
+    return messages
+      .filter(({ content }) => {
+        if (content === undefined) return false
+
+        // Filter out normal instances (non-confidential VMs)
+        return content.environment?.trusted_execution?.firmware
+      })
+      .map((message) => {
+        return {
+          id: message.item_hash,
+          ...message.content,
+          name: message.content.metadata?.name || 'Unnamed instance',
+          type: EntityType.Instance,
+          url: getExplorerURL(message),
+          date: getDate(message.time),
+          size: message.content.rootfs?.size_mib || 0,
+          confirmed: !!message.confirmed,
+        }
+      })
+  }
+}

--- a/src/domain/confidential.ts
+++ b/src/domain/confidential.ts
@@ -54,7 +54,6 @@ export class ConfidentialManager
       const response = await this.sdkClient.getMessages({
         addresses: [this.account.address],
         messageTypes: [MessageType.instance],
-        channels: [this.channel],
       })
 
       return await this.parseMessages(response.messages)

--- a/src/domain/instance.ts
+++ b/src/domain/instance.ts
@@ -388,7 +388,12 @@ export class InstanceManager
     /* const sizesMap = await this.fileManager.getSizesMap() */
 
     return messages
-      .filter(({ content }) => content !== undefined)
+      .filter(({ content }) => {
+        if (content === undefined) return false
+
+        // Filter out confidential VMs
+        return !content.environment?.trusted_execution?.firmware
+      })
       .map((message) => {
         /* const size = message.content.volumes.reduce(
           (ac: number, cv: MachineVolume) =>

--- a/src/domain/instance.ts
+++ b/src/domain/instance.ts
@@ -392,7 +392,7 @@ export class InstanceManager
         if (content === undefined) return false
 
         // Filter out confidential VMs
-        return !content.environment?.trusted_execution?.firmware
+        return !content.environment?.trusted_execution
       })
       .map((message) => {
         /* const size = message.content.volumes.reduce(

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -410,6 +410,11 @@ export class NodeManager {
     return nodes.find((node) => node.stream_reward === rewardAddress)
   }
 
+  async getCRNByHash(hash: string): Promise<CRN | undefined> {
+    const nodes = await this.getCRNNodes()
+    return nodes.find((node) => node.hash === hash)
+  }
+
   protected async fetchAllNodes(): Promise<NodesResponse> {
     return fetchAndCache(
       `${apiServer}/api/v0/aggregates/0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10.json?keys=corechannel&limit=100`,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -8,9 +8,7 @@ export interface EntityManagerFetchOptions {
   channels?: string[]
 }
 
-export interface EntityManager<T, AT> {
-  getAll(opts: EntityManagerFetchOptions): Promise<T[]>
-  get(id: string): Promise<T | undefined>
+export interface EntityManager<T, AT> extends ReadOnlyEntityManager<T> {
   add(entity: AT | AT[]): Promise<T | T[]>
   del(entityOrId: string | T): Promise<void>
 
@@ -22,4 +20,9 @@ export interface EntityManager<T, AT> {
     entity: string | T | (string | T)[],
     extra?: any,
   ): AsyncGenerator<void>
+}
+
+export interface ReadOnlyEntityManager<T> {
+  getAll(opts: EntityManagerFetchOptions): Promise<T[]>
+  get(id: string): Promise<T | undefined>
 }

--- a/src/domain/voucher.ts
+++ b/src/domain/voucher.ts
@@ -5,11 +5,13 @@ import {
 } from '@aleph-sdk/client'
 
 export type Voucher = {
+  id: string
   metadataId: string
   name: string
   description: string
   externalUrl: string
   image: string
+  icon: string
   attributes: {
     value: string | number
     traitType: string
@@ -36,18 +38,23 @@ export class VoucherManager {
       for (const voucherId in content.nft_vouchers) {
         const voucher = content.nft_vouchers[voucherId]
 
-        if (voucher.claimer === this.account.address) {
+        if (voucher?.claimer === this.account.address) {
           const metadataId = voucher.metadata_id
           const metadata = content.metadata[metadataId]
 
           if (metadata) {
+            const { name, description, external_url, image, icon, attributes } =
+              metadata
+
             vouchers.push({
+              id: voucherId,
               metadataId,
-              name: metadata.name,
-              description: metadata.description,
-              externalUrl: metadata.external_url,
-              image: metadata.image,
-              attributes: metadata.attributes.map((attr: any) => ({
+              name,
+              description,
+              externalUrl: external_url.replace('{id}', voucherId),
+              image: image,
+              icon: icon,
+              attributes: attributes.map((attr: any) => ({
                 value: attr.value,
                 traitType: attr.trait_type,
                 displayType: attr.display_type,

--- a/src/domain/voucher.ts
+++ b/src/domain/voucher.ts
@@ -1,0 +1,65 @@
+import { Account } from '@aleph-sdk/account'
+import {
+  AlephHttpClient,
+  AuthenticatedAlephHttpClient,
+} from '@aleph-sdk/client'
+
+export type Voucher = {
+  metadataId: string
+  name: string
+  description: string
+  externalUrl: string
+  image: string
+  attributes: {
+    value: string | number
+    traitType: string
+    displayType?: string
+  }
+}
+
+export class VoucherManager {
+  constructor(
+    protected account: Account,
+    protected sdkClient: AlephHttpClient | AuthenticatedAlephHttpClient,
+  ) {}
+
+  async getAll(): Promise<Voucher[]> {
+    if (!this.account) return []
+
+    try {
+      const { content } = await this.sdkClient.getPost({
+        types: 'vouchers-update',
+      })
+
+      const vouchers: Voucher[] = []
+
+      for (const voucherId in content.nft_vouchers) {
+        const voucher = content.nft_vouchers[voucherId]
+
+        if (voucher.claimer === this.account.address) {
+          const metadataId = voucher.metadata_id
+          const metadata = content.metadata[metadataId]
+
+          if (metadata) {
+            vouchers.push({
+              metadataId,
+              name: metadata.name,
+              description: metadata.description,
+              externalUrl: metadata.external_url,
+              image: metadata.image,
+              attributes: metadata.attributes.map((attr: any) => ({
+                value: attr.value,
+                traitType: attr.trait_type,
+                displayType: attr.display_type,
+              })),
+            })
+          }
+        }
+      }
+
+      return vouchers
+    } catch (err) {
+      return []
+    }
+  }
+}

--- a/src/domain/vouchers.ts
+++ b/src/domain/vouchers.ts
@@ -1,5 +1,6 @@
 import { ethers, providers } from 'ethers'
 
+//@note: for future development use VoucherManager from '@/domain/voucher'
 const provider = new providers.JsonRpcProvider('https://avalanche.drpc.org')
 const contractAddress = '0x44c9B8558067F12993Fed260C84debb89E66e93f'
 const contractABI = [

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -7,8 +7,8 @@ export const channel = 'FOUNDATION'
 export const tags = ['mainnet']
 export const postType = 'corechan-operation'
 
-export const apiServer = 'http://pyaleph-lab-2.aleph.cloud:4024'
-export const wsServer = 'wss://pyaleph-lab-2.aleph.cloud:4024'
+export const apiServer = 'https://api3.aleph.im'
+export const wsServer = 'wss://api3.aleph.im'
 export const mbPerAleph = 3
 
 export const scoringAddress = '0x4D52380D3191274a04846c89c069E6C3F2Ed94e4'

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -7,8 +7,8 @@ export const channel = 'FOUNDATION'
 export const tags = ['mainnet']
 export const postType = 'corechan-operation'
 
-export const apiServer = 'https://api3.aleph.im'
-export const wsServer = 'wss://api3.aleph.im'
+export const apiServer = 'http://pyaleph-lab-2.aleph.cloud:4024'
+export const wsServer = 'wss://pyaleph-lab-2.aleph.cloud:4024'
 export const mbPerAleph = 3
 
 export const scoringAddress = '0x4D52380D3191274a04846c89c069E6C3F2Ed94e4'

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -19,6 +19,7 @@ export default {
   UserCancelled: new Error('User cancelled the action'),
   InvalidNetwork: new Error('Invalid network'),
   InstanceNotFound: new Error('Instance not found'),
+  ConfidentialNotFound: new Error('Confidential not found'),
   FunctionNotFound: new Error('Function not found'),
   WebsiteNotFound: new Error('Website not found'),
   VolumeNotFound: new Error('Volume not found'),
@@ -35,6 +36,9 @@ export default {
   InvalidCodeType: new Error('Invalid function code type'),
   InvalidCRNAddress: new Error('Invalid CRN address'),
   InvalidCRNSpecs: new Error('Invalid CRN min specs'),
+  InvalidConfidentialNodeRequirements: new Error(
+    'Invalid Confidential VM Node Requirements',
+  ),
   CustomRuntimeNeeded: new Error('Custom runtime should be added'),
   ReceivedRequired: new Error(
     'Payment receiver is required for stream payments',

--- a/src/hooks/common/authorization/useAuthorization.ts
+++ b/src/hooks/common/authorization/useAuthorization.ts
@@ -1,0 +1,22 @@
+import { useAppState } from '@/contexts/appState'
+import { useConfidentialsAuthorization } from './useConfidentialsAuthorization'
+import { useMemo } from 'react'
+import {
+  AuthorizationDenyAction,
+  AuthorizationGrantAction,
+  AuthorizationState,
+} from '@/store/authorization'
+
+export function useAuthorization(): AuthorizationState {
+  const [{ authorization }, dispatch] = useAppState()
+
+  const authzConfidentials = useConfidentialsAuthorization()
+
+  useMemo(() => {
+    authzConfidentials
+      ? dispatch(new AuthorizationGrantAction({ features: ['confidentials'] }))
+      : dispatch(new AuthorizationDenyAction({ features: ['confidentials'] }))
+  }, [dispatch, authzConfidentials])
+
+  return authorization
+}

--- a/src/hooks/common/authorization/useConfidentialsAuthorization.ts
+++ b/src/hooks/common/authorization/useConfidentialsAuthorization.ts
@@ -1,0 +1,26 @@
+import { useAppState } from '@/contexts/appState'
+import { useMemo, useState } from 'react'
+
+const CONFIDENTIAL_VOUCHER_METADATA_ID = '3'
+
+export function useConfidentialsAuthorization(): boolean {
+  const [state] = useAppState()
+  const {
+    connection: { account },
+    manager: { voucherManager },
+    authorization: { confidentials },
+  } = state
+  const [accessConfidential, setAccessConfidential] = useState(confidentials)
+
+  useMemo(async () => {
+    if (!account) return setAccessConfidential(false)
+    if (!voucherManager) return setAccessConfidential(false)
+
+    const vouchers = await voucherManager.getAll()
+
+    if (vouchers.some((v) => v.metadataId === CONFIDENTIAL_VOUCHER_METADATA_ID))
+      setAccessConfidential(true)
+  }, [account, voucherManager])
+
+  return accessConfidential
+}

--- a/src/hooks/common/useAccountEntities.ts
+++ b/src/hooks/common/useAccountEntities.ts
@@ -11,10 +11,13 @@ import { useRequestVolumes } from './useRequestEntity/useRequestVolumes'
 import { useRequestPrograms } from './useRequestEntity/useRequestPrograms'
 import { useRequestWebsites } from './useRequestEntity/useRequestWebsites'
 import { useAppState } from '@/contexts/appState'
+import { useRequestConfidentials } from './useRequestEntity/useRequestConfidentials'
+import { Confidential } from '@/domain/confidential'
 
 export type UseAccountEntitiesReturn = {
   programs: Program[]
   instances: Instance[]
+  confidentials: Confidential[]
   volumes: Volume[]
   sshKeys: SSHKey[]
   domains: Domain[]
@@ -30,6 +33,9 @@ export function useAccountEntities(): UseAccountEntitiesReturn {
   const { entities: volumes = [] } = useRequestVolumes({ triggerDeps })
   const { entities: programs = [] } = useRequestPrograms({ triggerDeps })
   const { entities: instances = [] } = useRequestInstances({ triggerDeps })
+  const { entities: confidentials = [] } = useRequestConfidentials({
+    triggerDeps,
+  })
   const { entities: sshKeys = [] } = useRequestSSHKeys({ triggerDeps })
   const { entities: domains = [] } = useRequestDomains({ triggerDeps })
   const { entities: websites = [] } = useRequestWebsites({ triggerDeps })
@@ -38,6 +44,7 @@ export function useAccountEntities(): UseAccountEntitiesReturn {
     programs,
     volumes,
     instances,
+    confidentials,
     sshKeys,
     domains,
     websites,

--- a/src/hooks/common/useAttachedVolumes.ts
+++ b/src/hooks/common/useAttachedVolumes.ts
@@ -1,14 +1,11 @@
 import { Volume } from '@/domain/volume'
-import { ImmutableVolume } from '@aleph-sdk/message'
-import { Program } from '@/domain/program'
-import { Instance } from '@/domain/instance'
-import { Website } from '@/domain/website'
 import { useMemo } from 'react'
+import { useProgramsVolumesIds } from './useProgramsVolumesIds'
+import { useConfidentialsVolumesIds } from './useConfidentialsVolumesIds'
+import { useInstancesVolumesIds } from './useInstancesVolumesIds'
+import { useWebsitesVolumesIds } from './useWebsitesVolumesIds'
 
 export type UseAttachedVolumesProps = {
-  programs?: Program[]
-  instances?: Instance[]
-  websites?: Website[]
   volumes?: Volume[]
 }
 
@@ -27,67 +24,34 @@ export type UseAttachedVolumesReturn = {
   }
 }
 
-export function getProgramVolumes(programs?: Program[]): string[] {
-  if (!programs) return []
-
-  return programs.flatMap((prog) => {
-    const codeVolume = prog.code.ref
-    const runtimeVolume = prog.runtime.ref
-    const linkedVolumes = prog.volumes
-      .filter((vol): vol is ImmutableVolume => 'ref' in vol)
-      .map((vol) => vol.ref)
-
-    return [codeVolume, runtimeVolume, ...linkedVolumes]
-  })
-}
-
-export function getInstanceVolumes(instances?: Instance[]): string[] {
-  if (!instances) return []
-
-  return instances.flatMap((instance) =>
-    instance.volumes
-      .filter((vol): vol is ImmutableVolume => 'ref' in vol)
-      .map((vol) => vol.ref),
-  )
-}
-
-export function getWebsiteVolumes(websites?: Website[]): string[] {
-  if (!websites) return []
-
-  return websites.map((website) => website.volume_id)
-}
-
 export function useAttachedVolumes({
-  instances,
-  programs,
-  websites,
   volumes,
 }: UseAttachedVolumesProps = {}): UseAttachedVolumesReturn {
-  const programVolumeIds = useMemo(
-    () => getProgramVolumes(programs),
-    [programs],
-  )
-
-  const instanceVolumeIds = useMemo(
-    () => getInstanceVolumes(instances),
-    [instances],
-  )
-
-  const websiteVolumeIds = useMemo(
-    () => getWebsiteVolumes(websites),
-    [websites],
-  )
+  const programVolumeIds = useProgramsVolumesIds()
+  const instanceVolumeIds = useInstancesVolumesIds()
+  const confidentialVolumeIds = useConfidentialsVolumesIds()
+  const websiteVolumeIds = useWebsitesVolumesIds()
 
   const volumesMap = useMemo(
     () =>
-      [...programVolumeIds, ...instanceVolumeIds, ...websiteVolumeIds].reduce(
+      [
+        ...programVolumeIds,
+        ...instanceVolumeIds,
+        ...confidentialVolumeIds,
+        ...websiteVolumeIds,
+      ].reduce(
         (ac, cv) => {
           ac[cv] = true
           return ac
         },
         {} as Record<string, boolean>,
       ),
-    [programVolumeIds, instanceVolumeIds, websiteVolumeIds],
+    [
+      programVolumeIds,
+      instanceVolumeIds,
+      confidentialVolumeIds,
+      websiteVolumeIds,
+    ],
   )
 
   const result = useMemo(

--- a/src/hooks/common/useBreadcrumbNames.ts
+++ b/src/hooks/common/useBreadcrumbNames.ts
@@ -26,6 +26,7 @@ const defaultNames = {
   '/computing/function/[hash]': '-',
   '/computing/function/new': 'SETUP NEW FUNCTION',
   '/computing/confidential': 'COMPUTING / CONFIDENTIALS',
+  '/computing/confidential/[hash]': '-',
   '/hosting': '-',
   '/hosting/website': 'WEB3 HOSTING / WEBSITES',
   '/hosting/website/[hash]': '-',
@@ -52,6 +53,7 @@ export function useBreadcrumbNames(): UseBreadcrumbNamesReturn {
       '/settings/ssh/[hash]': `SSH KEYS / ${hash}`,
       '/settings/domain/[hash]': `DOMAINS / ${hashParam}`,
       '/computing/instance/[hash]': `${hash}`,
+      '/computing/confidential/[hash]': `${hash}`,
       '/computing/function/[hash]': `${hash}`,
       '/hosting/website/[hash]': `${hashParam}`,
     }

--- a/src/hooks/common/useBreadcrumbNames.ts
+++ b/src/hooks/common/useBreadcrumbNames.ts
@@ -25,6 +25,7 @@ const defaultNames = {
   '/computing/function': 'COMPUTING / FUNCTIONS',
   '/computing/function/[hash]': '-',
   '/computing/function/new': 'SETUP NEW FUNCTION',
+  '/computing/confidential': 'COMPUTING / CONFIDENTIALS',
   '/hosting': '-',
   '/hosting/website': 'WEB3 HOSTING / WEBSITES',
   '/hosting/website/[hash]': '-',

--- a/src/hooks/common/useConfidentialStatus.ts
+++ b/src/hooks/common/useConfidentialStatus.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { useConfidentialManager } from './useManager/useConfidentialManager'
+import { Confidential, ConfidentialStatus } from '@/domain/confidential'
+
+export type UseConfidentialStatusProps = Confidential | undefined
+
+export type UseConfidentialStatusReturn = ConfidentialStatus | undefined
+
+export function useConfidentialStatus(
+  confidential: UseConfidentialStatusProps,
+): UseConfidentialStatusReturn {
+  const [status, setStatus] = useState<ConfidentialStatus>(undefined)
+
+  const manager = useConfidentialManager()
+
+  useEffect(() => {
+    if (!manager) return
+    if (!confidential) return
+    if (status) return
+
+    async function request() {
+      if (!manager) return
+      if (!confidential) return
+
+      const status = await manager.checkStatus(confidential)
+      setStatus(status)
+    }
+
+    if (!status) request()
+
+    const id = setInterval(request, 10 * 1000)
+    return () => clearInterval(id)
+  }, [status, confidential, manager])
+
+  return status
+}

--- a/src/hooks/common/useConfidentialsVolumesIds.ts
+++ b/src/hooks/common/useConfidentialsVolumesIds.ts
@@ -1,0 +1,26 @@
+import { useMemo, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+import { ImmutableVolume } from '@aleph-sdk/message'
+
+export type useConfidentialsVolumesIdsReturn = string[]
+
+export function useConfidentialsVolumesIds(): useConfidentialsVolumesIdsReturn {
+  const [ids, setIds] = useState<string[]>([])
+
+  const [state] = useAppState()
+  const confidentials = state.confidential.entities
+
+  useMemo(() => {
+    if (!confidentials) return setIds([])
+
+    setIds(
+      confidentials.flatMap((confidential) => {
+        return confidential.volumes
+          .filter((vol): vol is ImmutableVolume => 'ref' in vol)
+          .map((vol) => vol.ref)
+      }),
+    )
+  }, [confidentials])
+
+  return ids
+}

--- a/src/hooks/common/useInstancesVolumesIds.ts
+++ b/src/hooks/common/useInstancesVolumesIds.ts
@@ -1,0 +1,26 @@
+import { useMemo, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+import { ImmutableVolume } from '@aleph-sdk/message'
+
+export type useInstancesVolumesIdsReturn = string[]
+
+export function useInstancesVolumesIds(): useInstancesVolumesIdsReturn {
+  const [ids, setIds] = useState<string[]>([])
+
+  const [state] = useAppState()
+  const instances = state.instance.entities
+
+  useMemo(() => {
+    if (!instances) return setIds([])
+
+    setIds(
+      instances.flatMap((instance) => {
+        return instance.volumes
+          .filter((vol): vol is ImmutableVolume => 'ref' in vol)
+          .map((vol) => vol.ref)
+      }),
+    )
+  }, [instances])
+
+  return ids
+}

--- a/src/hooks/common/useManager/useConfidentialManager.ts
+++ b/src/hooks/common/useManager/useConfidentialManager.ts
@@ -1,0 +1,9 @@
+import { useAppState } from '@/contexts/appState'
+import { ConfidentialManager } from '@/domain/confidential'
+
+export function useConfidentialManager(): ConfidentialManager | undefined {
+  const [appState] = useAppState()
+  const { confidentialManager } = appState.manager
+
+  return confidentialManager
+}

--- a/src/hooks/common/useManager/useVoucherManager.ts
+++ b/src/hooks/common/useManager/useVoucherManager.ts
@@ -1,0 +1,9 @@
+import { useAppState } from '@/contexts/appState'
+import { VoucherManager } from '@/domain/voucher'
+
+export function useVoucherManager(): VoucherManager | undefined {
+  const [appState] = useAppState()
+  const { voucherManager } = appState.manager
+
+  return voucherManager
+}

--- a/src/hooks/common/useProgramsVolumesIds.ts
+++ b/src/hooks/common/useProgramsVolumesIds.ts
@@ -1,0 +1,30 @@
+import { useMemo, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+import { ImmutableVolume } from '@aleph-sdk/message'
+
+export type useProgramsVolumesIdsReturn = string[]
+
+export function useProgramsVolumesIds(): useProgramsVolumesIdsReturn {
+  const [ids, setIds] = useState<string[]>([])
+
+  const [state] = useAppState()
+  const programs = state.program.entities
+
+  useMemo(() => {
+    if (!programs) return setIds([])
+
+    setIds(
+      programs.flatMap((program) => {
+        const codeVolume = program.code.ref
+        const runtimeVolume = program.runtime.ref
+        const linkedVolumes = program.volumes
+          .filter((vol): vol is ImmutableVolume => 'ref' in vol)
+          .map((vol) => vol.ref)
+
+        return [codeVolume, runtimeVolume, ...linkedVolumes]
+      }),
+    )
+  }, [programs])
+
+  return ids
+}

--- a/src/hooks/common/useRequestEntity/useRequestConfidentialDomains.ts
+++ b/src/hooks/common/useRequestEntity/useRequestConfidentialDomains.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react'
+import { Domain } from '@/domain/domain'
+import {
+  UseRequestEntitiesProps,
+  UseRequestEntitiesReturn,
+} from './useRequestEntities'
+import { useRequestDomains } from './useRequestDomains'
+import { useAppState } from '@/contexts/appState'
+
+export type UseRequestConfidentialDomainsProps = Omit<
+  UseRequestEntitiesProps<Domain>,
+  'name'
+>
+
+export type UseRequestConfidentialDomainsReturn =
+  UseRequestEntitiesReturn<Domain>
+
+export function useRequestConfidentialDomains(
+  props: UseRequestConfidentialDomainsProps = {},
+): UseRequestConfidentialDomainsReturn {
+  const [state] = useAppState()
+  const confidentials = state.confidential.entities
+
+  const { entities: domains } = useRequestDomains(props)
+
+  const entities = useMemo(() => {
+    if (!confidentials) return []
+    if (!domains) return []
+
+    const confidentialsMap = confidentials.reduce(
+      (ac, cv) => {
+        ac[cv.id] = true
+        return ac
+      },
+      {} as Record<string, boolean>,
+    )
+
+    return domains.filter((domain) => !!confidentialsMap[domain.ref])
+  }, [domains, confidentials])
+
+  return {
+    entities,
+  }
+}

--- a/src/hooks/common/useRequestEntity/useRequestConfidentialVolumes.ts
+++ b/src/hooks/common/useRequestEntity/useRequestConfidentialVolumes.ts
@@ -1,13 +1,11 @@
-import { useMemo } from 'react'
 import { Volume } from '@/domain/volume'
-import { useAppState } from '@/contexts/appState'
 import { useVolumeManager } from '../useManager/useVolumeManager'
 import {
   UseRequestEntitiesProps,
   UseRequestEntitiesReturn,
   useRequestEntities,
 } from './useRequestEntities'
-import { ImmutableVolume } from '@aleph-sdk/message'
+import { useConfidentialsVolumesIds } from '../useConfidentialsVolumesIds'
 
 export type UseRequestConfidentialVolumesProps = Omit<
   UseRequestEntitiesProps<Volume>,
@@ -20,20 +18,9 @@ export type UseRequestConfidentialVolumesReturn =
 export function useRequestConfidentialVolumes(
   props: UseRequestConfidentialVolumesProps = {},
 ): UseRequestConfidentialVolumesReturn {
-  const [state] = useAppState()
-  const confidentials = state.confidential.entities
-
-  const ids = useMemo(() => {
-    if (!confidentials) return []
-
-    return confidentials.flatMap((conf) => {
-      return conf.volumes
-        .filter((vol): vol is ImmutableVolume => 'ref' in vol)
-        .map((vol) => vol.ref)
-    })
-  }, [confidentials])
-
+  const ids = useConfidentialsVolumesIds()
   const manager = useVolumeManager()
+
   return useRequestEntities({
     ...props,
     manager,

--- a/src/hooks/common/useRequestEntity/useRequestConfidentialVolumes.ts
+++ b/src/hooks/common/useRequestEntity/useRequestConfidentialVolumes.ts
@@ -26,8 +26,8 @@ export function useRequestConfidentialVolumes(
   const ids = useMemo(() => {
     if (!confidentials) return []
 
-    return confidentials.flatMap((prog) => {
-      return prog.volumes
+    return confidentials.flatMap((conf) => {
+      return conf.volumes
         .filter((vol): vol is ImmutableVolume => 'ref' in vol)
         .map((vol) => vol.ref)
     })

--- a/src/hooks/common/useRequestEntity/useRequestConfidentialVolumes.ts
+++ b/src/hooks/common/useRequestEntity/useRequestConfidentialVolumes.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import { Volume } from '@/domain/volume'
+import { useAppState } from '@/contexts/appState'
+import { useVolumeManager } from '../useManager/useVolumeManager'
+import {
+  UseRequestEntitiesProps,
+  UseRequestEntitiesReturn,
+  useRequestEntities,
+} from './useRequestEntities'
+import { ImmutableVolume } from '@aleph-sdk/message'
+
+export type UseRequestConfidentialVolumesProps = Omit<
+  UseRequestEntitiesProps<Volume>,
+  'name'
+>
+
+export type UseRequestConfidentialVolumesReturn =
+  UseRequestEntitiesReturn<Volume>
+
+export function useRequestConfidentialVolumes(
+  props: UseRequestConfidentialVolumesProps = {},
+): UseRequestConfidentialVolumesReturn {
+  const [state] = useAppState()
+  const confidentials = state.confidential.entities
+
+  const ids = useMemo(() => {
+    if (!confidentials) return []
+
+    return confidentials.flatMap((prog) => {
+      return prog.volumes
+        .filter((vol): vol is ImmutableVolume => 'ref' in vol)
+        .map((vol) => vol.ref)
+    })
+  }, [confidentials])
+
+  const manager = useVolumeManager()
+  return useRequestEntities({
+    ...props,
+    manager,
+    name: 'confidentialVolume',
+    ids,
+  })
+}

--- a/src/hooks/common/useRequestEntity/useRequestConfidentials.ts
+++ b/src/hooks/common/useRequestEntity/useRequestConfidentials.ts
@@ -1,0 +1,22 @@
+import { Confidential } from '@/domain/confidential'
+import {
+  UseRequestEntitiesProps,
+  UseRequestEntitiesReturn,
+  useRequestEntities,
+} from './useRequestEntities'
+import { useConfidentialManager } from '../useManager/useConfidentialManager'
+
+export type UseRequestConfidentialsProps = Omit<
+  UseRequestEntitiesProps<Confidential>,
+  'name'
+>
+
+export type UseRequestConfidentialsReturn =
+  UseRequestEntitiesReturn<Confidential>
+
+export function useRequestConfidentials(
+  props: UseRequestConfidentialsProps = {},
+): UseRequestConfidentialsReturn {
+  const manager = useConfidentialManager()
+  return useRequestEntities({ ...props, manager, name: 'confidential' })
+}

--- a/src/hooks/common/useRequestEntity/useRequestEntities.ts
+++ b/src/hooks/common/useRequestEntity/useRequestEntities.ts
@@ -4,12 +4,12 @@ import {
   useRetryNotConfirmedEntities,
 } from '../useRetryNotConfirmedEntities'
 import { useAppState } from '@/contexts/appState'
-import { EntityManager } from '@/domain/types'
+import { EntityManager, ReadOnlyEntityManager } from '@/domain/types'
 import { StoreState } from '@/store/store'
 
 export type UseRequestEntitiesProps<Entity> = {
   name: keyof StoreState
-  manager?: EntityManager<Entity, any>
+  manager?: EntityManager<Entity, any> | ReadOnlyEntityManager<Entity>
   ids?: string | string[]
   triggerOnMount?: boolean
   triggerDeps?: unknown[]

--- a/src/hooks/common/useRequestEntity/useRequestExecutableStatus.ts
+++ b/src/hooks/common/useRequestEntity/useRequestExecutableStatus.ts
@@ -5,6 +5,8 @@ import { useInstanceManager } from '../useManager/useInstanceManager'
 
 export type UseRequestExecutableStatusProps = {
   entities?: Executable[]
+  //@todo: fix managerHook type
+  managerHook?: any
 }
 
 export type UseRequestExecutableStatusReturn = {
@@ -14,8 +16,9 @@ export type UseRequestExecutableStatusReturn = {
 
 export function useRequestExecutableStatus({
   entities,
+  managerHook = useInstanceManager,
 }: UseRequestExecutableStatusProps): UseRequestExecutableStatusReturn {
-  const manager = useInstanceManager()
+  const manager = managerHook()
 
   const [status, setStatus] = useState<
     Record<string, RequestState<ExecutableStatus>>

--- a/src/hooks/common/useRequestEntity/useRequestProgramVolumes.ts
+++ b/src/hooks/common/useRequestEntity/useRequestProgramVolumes.ts
@@ -1,13 +1,11 @@
-import { useMemo } from 'react'
 import { Volume } from '@/domain/volume'
-import { useAppState } from '@/contexts/appState'
 import { useVolumeManager } from '../useManager/useVolumeManager'
 import {
   UseRequestEntitiesProps,
   UseRequestEntitiesReturn,
   useRequestEntities,
 } from './useRequestEntities'
-import { ImmutableVolume } from '@aleph-sdk/message'
+import { useProgramsVolumesIds } from '../useProgramsVolumesIds'
 
 export type UseRequestProgramVolumesProps = Omit<
   UseRequestEntitiesProps<Volume>,
@@ -19,22 +17,8 @@ export type UseRequestProgramVolumesReturn = UseRequestEntitiesReturn<Volume>
 export function useRequestProgramVolumes(
   props: UseRequestProgramVolumesProps = {},
 ): UseRequestProgramVolumesReturn {
-  const [state] = useAppState()
-  const programs = state.program.entities
-
-  const ids = useMemo(() => {
-    if (!programs) return []
-
-    return programs.flatMap((prog) => {
-      const codeVolume = prog.code.ref
-      const linkedVolumes = prog.volumes
-        .filter((vol): vol is ImmutableVolume => 'ref' in vol)
-        .map((vol) => vol.ref)
-
-      return [codeVolume, ...linkedVolumes]
-    })
-  }, [programs])
-
+  const ids = useProgramsVolumesIds()
   const manager = useVolumeManager()
+
   return useRequestEntities({ ...props, manager, name: 'programVolume', ids })
 }

--- a/src/hooks/common/useRoutes.ts
+++ b/src/hooks/common/useRoutes.ts
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react'
 import { useAuthorization } from './authorization/useAuthorization'
 
 const DEFAULT_CONFIDENTIAL_ROUTE: Route = {
-  name: 'Confidential',
+  name: 'Confidentials',
   href: '/computing/confidential',
   disabled: true,
   label: '(SOON)',
@@ -23,7 +23,7 @@ export function useRoutes(): UseRoutesReturn {
   useMemo(async () => {
     confidentialsAuthz
       ? setConfidentialRoute({
-          name: 'Confidential',
+          name: 'Confidentials',
           href: '/computing/confidential',
           label: '(BETA)',
           icon: 'confidential',

--- a/src/hooks/common/useRoutes.ts
+++ b/src/hooks/common/useRoutes.ts
@@ -1,11 +1,48 @@
+import { useAppState } from '@/contexts/appState'
 import { Route } from '@aleph-front/core'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 export type UseRoutesReturn = {
   routes: Route[]
 }
-
 export function useRoutes(): UseRoutesReturn {
+  const [state] = useAppState()
+  const {
+    connection: { account },
+    manager: { voucherManager },
+  } = state
+
+  const CONFIDENTIAL_VOUCHER_METADATA_ID = '3'
+  const DEFAULT_CONFIDENTIAL_ROUTE: Route = useMemo(
+    () => ({
+      name: 'Confidential',
+      href: '/computing/confidential',
+      disabled: true,
+      label: '(SOON)',
+      icon: 'confidential',
+    }),
+    [],
+  )
+
+  const [confidentialRoute, setConfidentialRoute] = useState<Route>(
+    DEFAULT_CONFIDENTIAL_ROUTE,
+  )
+
+  useMemo(async () => {
+    if (!account) return setConfidentialRoute(DEFAULT_CONFIDENTIAL_ROUTE)
+    if (!voucherManager) return setConfidentialRoute(DEFAULT_CONFIDENTIAL_ROUTE)
+
+    const vouchers = await voucherManager.getAll()
+
+    if (vouchers.some((v) => v.metadataId === CONFIDENTIAL_VOUCHER_METADATA_ID))
+      setConfidentialRoute({
+        name: 'Confidential',
+        href: '/computing/confidential',
+        label: '(BETA)',
+        icon: 'confidential',
+      })
+  }, [DEFAULT_CONFIDENTIAL_ROUTE, account, voucherManager])
+
   const routes: Route[] = useMemo(() => {
     return [
       {
@@ -57,13 +94,7 @@ export function useRoutes(): UseRoutesReturn {
                     href: '/computing/instance',
                     icon: 'instance',
                   },
-                  {
-                    name: 'Confidential',
-                    href: '/computing/confidential',
-                    disabled: true,
-                    label: '(SOON)',
-                    icon: 'confidential',
-                  },
+                  confidentialRoute,
                 ],
               },
               {
@@ -127,7 +158,7 @@ export function useRoutes(): UseRoutesReturn {
         external: true,
       },
     ] as Route[]
-  }, [])
+  }, [confidentialRoute])
 
   return {
     routes,

--- a/src/hooks/common/useRoutes.ts
+++ b/src/hooks/common/useRoutes.ts
@@ -1,47 +1,35 @@
-import { useAppState } from '@/contexts/appState'
 import { Route } from '@aleph-front/core'
 import { useMemo, useState } from 'react'
+import { useAuthorization } from './authorization/useAuthorization'
+
+const DEFAULT_CONFIDENTIAL_ROUTE: Route = {
+  name: 'Confidential',
+  href: '/computing/confidential',
+  disabled: true,
+  label: '(SOON)',
+  icon: 'confidential',
+}
 
 export type UseRoutesReturn = {
   routes: Route[]
 }
 export function useRoutes(): UseRoutesReturn {
-  const [state] = useAppState()
-  const {
-    connection: { account },
-    manager: { voucherManager },
-  } = state
-
-  const CONFIDENTIAL_VOUCHER_METADATA_ID = '3'
-  const DEFAULT_CONFIDENTIAL_ROUTE: Route = useMemo(
-    () => ({
-      name: 'Confidential',
-      href: '/computing/confidential',
-      disabled: true,
-      label: '(SOON)',
-      icon: 'confidential',
-    }),
-    [],
-  )
+  const { confidentials: confidentialsAuthz } = useAuthorization()
 
   const [confidentialRoute, setConfidentialRoute] = useState<Route>(
     DEFAULT_CONFIDENTIAL_ROUTE,
   )
 
   useMemo(async () => {
-    if (!account) return setConfidentialRoute(DEFAULT_CONFIDENTIAL_ROUTE)
-    if (!voucherManager) return setConfidentialRoute(DEFAULT_CONFIDENTIAL_ROUTE)
-
-    const vouchers = await voucherManager.getAll()
-
-    if (vouchers.some((v) => v.metadataId === CONFIDENTIAL_VOUCHER_METADATA_ID))
-      setConfidentialRoute({
-        name: 'Confidential',
-        href: '/computing/confidential',
-        label: '(BETA)',
-        icon: 'confidential',
-      })
-  }, [DEFAULT_CONFIDENTIAL_ROUTE, account, voucherManager])
+    confidentialsAuthz
+      ? setConfidentialRoute({
+          name: 'Confidential',
+          href: '/computing/confidential',
+          label: '(BETA)',
+          icon: 'confidential',
+        })
+      : setConfidentialRoute(DEFAULT_CONFIDENTIAL_ROUTE)
+  }, [confidentialsAuthz])
 
   const routes: Route[] = useMemo(() => {
     return [

--- a/src/hooks/common/useRoutes.ts
+++ b/src/hooks/common/useRoutes.ts
@@ -10,6 +10,13 @@ const DEFAULT_CONFIDENTIAL_ROUTE: Route = {
   icon: 'confidential',
 }
 
+const BETA_CONFIDENTIAL_ROUTE_BETA: Route = {
+  ...DEFAULT_CONFIDENTIAL_ROUTE,
+  disabled: false,
+  label: '(BETA)',
+  icon: 'confidential',
+}
+
 export type UseRoutesReturn = {
   routes: Route[]
 }
@@ -20,14 +27,9 @@ export function useRoutes(): UseRoutesReturn {
     DEFAULT_CONFIDENTIAL_ROUTE,
   )
 
-  useMemo(async () => {
+  useMemo(() => {
     confidentialsAuthz
-      ? setConfidentialRoute({
-          name: 'Confidentials',
-          href: '/computing/confidential',
-          label: '(BETA)',
-          icon: 'confidential',
-        })
+      ? setConfidentialRoute(BETA_CONFIDENTIAL_ROUTE_BETA)
       : setConfidentialRoute(DEFAULT_CONFIDENTIAL_ROUTE)
   }, [confidentialsAuthz])
 

--- a/src/hooks/common/useWebsitesVolumesIds.ts
+++ b/src/hooks/common/useWebsitesVolumesIds.ts
@@ -1,0 +1,19 @@
+import { useMemo, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+
+export type useWebsitesVolumesIdsReturn = string[]
+
+export function useWebsitesVolumesIds(): useWebsitesVolumesIdsReturn {
+  const [ids, setIds] = useState<string[]>([])
+
+  const [state] = useAppState()
+  const websites = state.website.entities
+
+  useMemo(() => {
+    if (!websites) return setIds([])
+
+    setIds(websites.flatMap((website) => website.volume_id))
+  }, [websites])
+
+  return ids
+}

--- a/src/hooks/pages/computing/useConfidentialDashboardPage.ts
+++ b/src/hooks/pages/computing/useConfidentialDashboardPage.ts
@@ -1,15 +1,17 @@
 import { useMemo, useState } from 'react'
 import { TabsProps } from '@aleph-front/core'
 import { Volume } from '@/domain/volume'
-import { useRequestInstanceVolumes } from '@/hooks/common/useRequestEntity/useRequestInstanceVolumes'
-import { useRequestInstanceDomains } from '@/hooks/common/useRequestEntity/useRequestInstanceDomains'
 import { Domain } from '@/domain/domain'
 import { useRequestConfidentials } from '@/hooks/common/useRequestEntity/useRequestConfidentials'
 import { Confidential } from '@/domain/confidential'
 import { useRequestConfidentialVolumes } from '@/hooks/common/useRequestEntity/useRequestConfidentialVolumes'
 import { useRequestConfidentialDomains } from '@/hooks/common/useRequestEntity/useRequestConfidentialDomains'
+import { useAuthorization } from '@/hooks/common/authorization/useAuthorization'
+import { useRouter } from 'next/router'
 
 export type UseConfidentialDashboardPageReturn = {
+  authorized: boolean
+  onUnauthorized: () => void
   confidentials: Confidential[]
   volumes: Volume[]
   domains: Domain[]
@@ -25,6 +27,11 @@ function getLabel(entities: unknown[], beta = false): string {
 }
 
 export function useConfidentialDashboardPage(): UseConfidentialDashboardPageReturn {
+  const { push } = useRouter()
+  const { confidentials: confidentialsAuthz } = useAuthorization()
+
+  const onUnauthorized = () => push('/')
+
   const { entities: confidentials = [] } = useRequestConfidentials()
   const { entities: volumes = [] } = useRequestConfidentialVolumes()
   const { entities: domains = [] } = useRequestConfidentialDomains()
@@ -54,6 +61,8 @@ export function useConfidentialDashboardPage(): UseConfidentialDashboardPageRetu
   }, [domains, confidentials, volumes])
 
   return {
+    authorized: confidentialsAuthz,
+    onUnauthorized,
     confidentials,
     volumes,
     domains,

--- a/src/hooks/pages/computing/useConfidentialDashboardPage.ts
+++ b/src/hooks/pages/computing/useConfidentialDashboardPage.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { TabsProps } from '@aleph-front/core'
 import { Volume } from '@/domain/volume'
 import { Domain } from '@/domain/domain'
@@ -11,7 +11,6 @@ import { useRouter } from 'next/router'
 
 export type UseConfidentialDashboardPageReturn = {
   authorized: boolean
-  handleUnauthorized: () => void
   confidentials: Confidential[]
   volumes: Volume[]
   domains: Domain[]
@@ -28,9 +27,7 @@ function getLabel(entities: unknown[], beta = false): string {
 
 export function useConfidentialDashboardPage(): UseConfidentialDashboardPageReturn {
   const { push } = useRouter()
-  const { confidentials: confidentialsAuthz } = useAuthorization()
-
-  const handleUnauthorized = () => push('/')
+  const { confidentials: authorized } = useAuthorization()
 
   const { entities: confidentials = [] } = useRequestConfidentials()
   const { entities: volumes = [] } = useRequestConfidentialVolumes()
@@ -60,9 +57,12 @@ export function useConfidentialDashboardPage(): UseConfidentialDashboardPageRetu
     ]
   }, [domains, confidentials, volumes])
 
+  useEffect(() => {
+    if (!authorized) push('/')
+  }, [authorized, push])
+
   return {
-    authorized: confidentialsAuthz,
-    handleUnauthorized,
+    authorized,
     confidentials,
     volumes,
     domains,

--- a/src/hooks/pages/computing/useConfidentialDashboardPage.ts
+++ b/src/hooks/pages/computing/useConfidentialDashboardPage.ts
@@ -11,7 +11,7 @@ import { useRouter } from 'next/router'
 
 export type UseConfidentialDashboardPageReturn = {
   authorized: boolean
-  onUnauthorized: () => void
+  handleUnauthorized: () => void
   confidentials: Confidential[]
   volumes: Volume[]
   domains: Domain[]
@@ -30,7 +30,7 @@ export function useConfidentialDashboardPage(): UseConfidentialDashboardPageRetu
   const { push } = useRouter()
   const { confidentials: confidentialsAuthz } = useAuthorization()
 
-  const onUnauthorized = () => push('/')
+  const handleUnauthorized = () => push('/')
 
   const { entities: confidentials = [] } = useRequestConfidentials()
   const { entities: volumes = [] } = useRequestConfidentialVolumes()
@@ -62,7 +62,7 @@ export function useConfidentialDashboardPage(): UseConfidentialDashboardPageRetu
 
   return {
     authorized: confidentialsAuthz,
-    onUnauthorized,
+    handleUnauthorized,
     confidentials,
     volumes,
     domains,

--- a/src/hooks/pages/computing/useConfidentialDashboardPage.ts
+++ b/src/hooks/pages/computing/useConfidentialDashboardPage.ts
@@ -1,0 +1,64 @@
+import { useMemo, useState } from 'react'
+import { TabsProps } from '@aleph-front/core'
+import { Volume } from '@/domain/volume'
+import { useRequestInstanceVolumes } from '@/hooks/common/useRequestEntity/useRequestInstanceVolumes'
+import { useRequestInstanceDomains } from '@/hooks/common/useRequestEntity/useRequestInstanceDomains'
+import { Domain } from '@/domain/domain'
+import { useRequestConfidentials } from '@/hooks/common/useRequestEntity/useRequestConfidentials'
+import { Confidential } from '@/domain/confidential'
+import { useRequestConfidentialVolumes } from '@/hooks/common/useRequestEntity/useRequestConfidentialVolumes'
+import { useRequestConfidentialDomains } from '@/hooks/common/useRequestEntity/useRequestConfidentialDomains'
+
+export type UseConfidentialDashboardPageReturn = {
+  confidentials: Confidential[]
+  volumes: Volume[]
+  domains: Domain[]
+  tabs: TabsProps['tabs']
+  tabId: string
+  setTabId: (tab: string) => void
+}
+
+function getLabel(entities: unknown[], beta = false): string {
+  const n = entities.length > 0 ? `(${entities.length})` : ''
+  const b = beta ? 'BETA ' : ''
+  return `${b}${n}`
+}
+
+export function useConfidentialDashboardPage(): UseConfidentialDashboardPageReturn {
+  const { entities: confidentials = [] } = useRequestConfidentials()
+  const { entities: volumes = [] } = useRequestConfidentialVolumes()
+  const { entities: domains = [] } = useRequestConfidentialDomains()
+
+  const [tabId, setTabId] = useState('confidential')
+
+  const tabs: TabsProps['tabs'] = useMemo(() => {
+    return [
+      {
+        id: 'confidential',
+        name: 'Confidentials',
+        label: { label: getLabel(confidentials), position: 'bottom' },
+      },
+      {
+        id: 'volume',
+        name: 'Attached Volumes',
+        label: { label: getLabel(volumes), position: 'bottom' },
+        disabled: !volumes.length,
+      },
+      {
+        id: 'domain',
+        name: 'Linked Domains',
+        label: { label: getLabel(domains), position: 'bottom' },
+        disabled: !domains.length,
+      },
+    ]
+  }, [domains, confidentials, volumes])
+
+  return {
+    confidentials,
+    volumes,
+    domains,
+    tabs,
+    tabId,
+    setTabId,
+  }
+}

--- a/src/hooks/pages/solutions/manage/useManageConfidential.ts
+++ b/src/hooks/pages/solutions/manage/useManageConfidential.ts
@@ -10,9 +10,11 @@ import { useCopyToClipboardAndNotify } from '@aleph-front/core'
 import { useNodeManager } from '@/hooks/common/useManager/useNodeManager'
 import { CRN } from '@/domain/node'
 import { useAuthorization } from '@/hooks/common/authorization/useAuthorization'
+import { DefaultTheme, useTheme } from 'styled-components'
 
 export type ManageConfidential = {
   authorized: boolean
+  theme: DefaultTheme
   confidential?: Confidential
   status?: ConfidentialStatus
   mappedKeys: (SSHKey | undefined)[]
@@ -22,17 +24,22 @@ export type ManageConfidential = {
   handleCopyConnect: () => void
   handleCopyIpv6: () => void
   handleBack: () => void
-  handleUnauthorized: () => void
 }
 
 export function useManageConfidential(): ManageConfidential {
+  const theme = useTheme()
   const router = useRouter()
   const {
     push,
     query: { hash },
   } = router
 
-  const { confidentials: confidentialsAuthz } = useAuthorization()
+  const { confidentials: authorized } = useAuthorization()
+
+  useEffect(() => {
+    if (!authorized) push('/')
+  }, [authorized, push])
+
   const { entities } = useRequestConfidentials({ ids: hash as string })
   const [confidential] = entities || []
 
@@ -97,13 +104,13 @@ export function useManageConfidential(): ManageConfidential {
     }
   }, [crn, status?.node])
 
-  const handleUnauthorized = () => push('/')
   const handleBack = () => {
     push('.')
   }
 
   return {
-    authorized: confidentialsAuthz,
+    authorized,
+    theme,
     confidential,
     status,
     mappedKeys,
@@ -113,6 +120,5 @@ export function useManageConfidential(): ManageConfidential {
     handleCopyConnect,
     handleCopyIpv6,
     handleBack,
-    handleUnauthorized,
   }
 }

--- a/src/hooks/pages/solutions/manage/useManageConfidential.ts
+++ b/src/hooks/pages/solutions/manage/useManageConfidential.ts
@@ -1,0 +1,118 @@
+import { useRouter } from 'next/router'
+import { useEffect, useMemo, useState } from 'react'
+import { Confidential, ConfidentialStatus } from '@/domain/confidential'
+import { useConfidentialStatus } from '@/hooks/common/useConfidentialStatus'
+import { useSSHKeyManager } from '@/hooks/common/useManager/useSSHKeyManager'
+import { SSHKey } from '@/domain/ssh'
+import { PaymentType } from '@aleph-sdk/message'
+import { useRequestConfidentials } from '@/hooks/common/useRequestEntity/useRequestConfidentials'
+import { useCopyToClipboardAndNotify } from '@aleph-front/core'
+import { useNodeManager } from '@/hooks/common/useManager/useNodeManager'
+import { CRN } from '@/domain/node'
+import { useAuthorization } from '@/hooks/common/authorization/useAuthorization'
+
+export type ManageConfidential = {
+  authorized: boolean
+  confidential?: Confidential
+  status?: ConfidentialStatus
+  mappedKeys: (SSHKey | undefined)[]
+  crn?: CRN
+  nodeDetails?: { name: string; url: string }
+  handleCopyHash: () => void
+  handleCopyConnect: () => void
+  handleCopyIpv6: () => void
+  handleBack: () => void
+  handleUnauthorized: () => void
+}
+
+export function useManageConfidential(): ManageConfidential {
+  const router = useRouter()
+  const {
+    push,
+    query: { hash },
+  } = router
+
+  const { confidentials: confidentialsAuthz } = useAuthorization()
+  const { entities } = useRequestConfidentials({ ids: hash as string })
+  const [confidential] = entities || []
+
+  const [mappedKeys, setMappedKeys] = useState<(SSHKey | undefined)[]>([])
+  const status = useConfidentialStatus(confidential)
+
+  const handleCopyHash = useCopyToClipboardAndNotify(confidential?.id || '')
+  const handleCopyIpv6 = useCopyToClipboardAndNotify(status?.vm_ipv6 || '')
+  const handleCopyConnect = useCopyToClipboardAndNotify(
+    `ssh root@${status?.vm_ipv6}`,
+  )
+
+  const nodeManager = useNodeManager()
+  const sshKeyManager = useSSHKeyManager()
+
+  useEffect(() => {
+    if (!confidential || !sshKeyManager) return
+    const getMapped = async () => {
+      const mapped = await sshKeyManager?.getByValues(
+        confidential.authorized_keys || [],
+      )
+      setMappedKeys(mapped)
+    }
+
+    getMapped()
+  }, [sshKeyManager, confidential])
+
+  const [crn, setCRN] = useState<CRN>()
+
+  useEffect(() => {
+    async function load() {
+      try {
+        if (!nodeManager) throw new Error()
+        if (!confidential) throw new Error()
+        if (confidential.payment?.type !== PaymentType.superfluid)
+          throw new Error()
+
+        const { receiver } = confidential.payment || {}
+        if (!receiver) throw new Error()
+
+        const node = await nodeManager.getCRNByStreamRewardAddress(receiver)
+        setCRN(node)
+      } catch {
+        setCRN(undefined)
+      }
+    }
+    load()
+  }, [confidential, nodeManager])
+
+  const nodeDetails = useMemo(() => {
+    if (status?.node) {
+      return {
+        name: status.node.node_id,
+        url: status.node.url,
+      }
+    }
+    if (crn) {
+      return {
+        name: crn.name || crn.hash,
+        url: crn.address || '',
+      }
+    }
+  }, [crn, status?.node])
+
+  const handleUnauthorized = () => push('/')
+  const handleBack = () => {
+    push('.')
+  }
+
+  return {
+    authorized: confidentialsAuthz,
+    confidential,
+    status,
+    mappedKeys,
+    crn,
+    nodeDetails,
+    handleCopyHash,
+    handleCopyConnect,
+    handleCopyIpv6,
+    handleBack,
+    handleUnauthorized,
+  }
+}

--- a/src/hooks/pages/solutions/useDashboardPage.ts
+++ b/src/hooks/pages/solutions/useDashboardPage.ts
@@ -8,6 +8,7 @@ import { RequestState } from '@aleph-front/core'
 import { ExecutableStatus } from '@/domain/executable'
 import { useAttachedVolumes } from '@/hooks/common/useAttachedVolumes'
 import { useAuthorization } from '@/hooks/common/authorization/useAuthorization'
+import { useConfidentialManager } from '@/hooks/common/useManager/useConfidentialManager'
 
 export type AmountAggregatedStatus = {
   amount: number
@@ -26,6 +27,10 @@ export type ComputingAggregatedStatus = {
 }
 
 export type InstancesAggregatedStatus = {
+  total: ComputingAggregatedStatus
+}
+
+export type ConfidentialsAggregatedStatus = {
   total: ComputingAggregatedStatus
 }
 
@@ -48,6 +53,7 @@ export type VolumesAggregatedStatus = {
 export type UseDashboardPageReturn = {
   programAggregatedStatus: ProgramsAggregatedStatus
   instanceAggregatedStatus: InstancesAggregatedStatus
+  confidentialsAggregatedStatus: ConfidentialsAggregatedStatus
   volumesAggregatedStatus: VolumesAggregatedStatus
   websitesAggregatedStatus: WebsitesAggregatedStatus
   confidentialsAuthz: boolean
@@ -97,6 +103,11 @@ export function useDashboardPage(): UseDashboardPageReturn {
     entities: instances,
   })
 
+  const { status: confidentialsStatus } = useRequestExecutableStatus({
+    entities: confidentials,
+    managerHook: useConfidentialManager,
+  })
+
   const programAggregatedStatus = useMemo(() => {
     return {
       total: calculateComputingAggregatedStatus({
@@ -123,6 +134,16 @@ export function useDashboardPage(): UseDashboardPageReturn {
     }
   }, [instancesStatus, instances])
 
+  // @todo: Check if this is correct
+  const confidentialsAggregatedStatus = useMemo(() => {
+    return {
+      total: calculateComputingAggregatedStatus({
+        entities: confidentials,
+        entitiesStatus: confidentialsStatus,
+      }),
+    }
+  }, [confidentials, confidentialsStatus])
+
   const volumesAggregatedStatus = useAttachedVolumes({
     programs,
     instances,
@@ -137,6 +158,7 @@ export function useDashboardPage(): UseDashboardPageReturn {
   return {
     programAggregatedStatus,
     instanceAggregatedStatus,
+    confidentialsAggregatedStatus,
     volumesAggregatedStatus,
     websitesAggregatedStatus,
     confidentialsAuthz,

--- a/src/hooks/pages/solutions/useDashboardPage.ts
+++ b/src/hooks/pages/solutions/useDashboardPage.ts
@@ -7,6 +7,7 @@ import { Instance } from '@/domain/instance'
 import { RequestState } from '@aleph-front/core'
 import { ExecutableStatus } from '@/domain/executable'
 import { useAttachedVolumes } from '@/hooks/common/useAttachedVolumes'
+import { useAuthorization } from '@/hooks/common/authorization/useAuthorization'
 
 export type AmountAggregatedStatus = {
   amount: number
@@ -49,6 +50,7 @@ export type UseDashboardPageReturn = {
   instanceAggregatedStatus: InstancesAggregatedStatus
   volumesAggregatedStatus: VolumesAggregatedStatus
   websitesAggregatedStatus: WebsitesAggregatedStatus
+  confidentialsAuthz: boolean
 }
 
 function calculateComputingAggregatedStatus({
@@ -82,7 +84,10 @@ function calculateComputingAggregatedStatus({
 export function useDashboardPage(): UseDashboardPageReturn {
   useSPARedirect()
 
-  const { programs, instances, websites, volumes } = useAccountEntities()
+  const { confidentials: confidentialsAuthz } = useAuthorization()
+
+  const { programs, instances, confidentials, websites, volumes } =
+    useAccountEntities()
 
   const { status: programsStatus } = useRequestExecutableStatus({
     entities: programs,
@@ -134,5 +139,6 @@ export function useDashboardPage(): UseDashboardPageReturn {
     instanceAggregatedStatus,
     volumesAggregatedStatus,
     websitesAggregatedStatus,
+    confidentialsAuthz,
   }
 }

--- a/src/hooks/pages/solutions/useDashboardPage.ts
+++ b/src/hooks/pages/solutions/useDashboardPage.ts
@@ -68,11 +68,12 @@ function calculateComputingAggregatedStatus({
 }) {
   return entities.reduce(
     (ac, cv) => {
-      const statusKey = !cv.confirmed
-        ? 'booting'
-        : !!entitiesStatus[cv.id]?.data?.vm_ipv6
-          ? 'running'
-          : 'paused'
+      const hasIpv6 = !!entitiesStatus[cv.id]?.data?.vm_ipv6
+      const statusKey = hasIpv6
+        ? 'running'
+        : cv.confirmed
+          ? 'paused'
+          : 'booting'
 
       ac[statusKey] += 1
       ac.amount += 1
@@ -145,9 +146,6 @@ export function useDashboardPage(): UseDashboardPageReturn {
   }, [confidentials, confidentialsStatus])
 
   const volumesAggregatedStatus = useAttachedVolumes({
-    programs,
-    instances,
-    websites,
     volumes,
   })
 

--- a/src/hooks/pages/storage/useStorageDashboardPage.ts
+++ b/src/hooks/pages/storage/useStorageDashboardPage.ts
@@ -22,7 +22,7 @@ function getLabel(entities: unknown[], beta = false): string {
 }
 
 export function useStorageDashboardPage(): UseStorageDashboardPageReturn {
-  const { programs, instances, websites, volumes } = useAccountEntities()
+  const { volumes } = useAccountEntities()
 
   const [tabId, setTabId] = useState('volume')
 
@@ -37,9 +37,6 @@ export function useStorageDashboardPage(): UseStorageDashboardPageReturn {
   }, [volumes])
 
   const volumesAggregatedStorage = useAttachedVolumes({
-    programs,
-    instances,
-    websites,
     volumes,
   })
 

--- a/src/pages/computing/confidential/[hash].tsx
+++ b/src/pages/computing/confidential/[hash].tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/pages/dashboard/ManageConfidential'

--- a/src/pages/computing/confidential/index.ts
+++ b/src/pages/computing/confidential/index.ts
@@ -1,0 +1,1 @@
+export { default } from '@/components/pages/computing/ConfidentialDashboardPage'

--- a/src/store/authorization.ts
+++ b/src/store/authorization.ts
@@ -1,0 +1,75 @@
+import { StoreReducer } from './store'
+
+export type AuthorizationState = {
+  confidentials: boolean
+}
+
+export const initialState: AuthorizationState = {
+  confidentials: false,
+}
+
+export enum AuthorizationActionType {
+  AUTHORIZATION_GRANT = 'AUTHORIZATION_GRANT',
+  AUTHORIZATION_DENY = 'AUTHORIZATION_DENY',
+}
+
+export class AuthorizationGrantAction {
+  readonly type = AuthorizationActionType.AUTHORIZATION_GRANT
+  constructor(
+    public payload: {
+      features: (keyof AuthorizationState)[]
+    },
+  ) {}
+}
+
+export class AuthorizationDenyAction {
+  readonly type = AuthorizationActionType.AUTHORIZATION_DENY
+  constructor(
+    public payload: {
+      features: (keyof AuthorizationState)[]
+    },
+  ) {}
+}
+
+export type AuthorizationAction =
+  | AuthorizationGrantAction
+  | AuthorizationDenyAction
+
+export type AuthorizationReducer = StoreReducer<
+  AuthorizationState,
+  AuthorizationAction
+>
+
+export function getAuthorizationReducer(): AuthorizationReducer {
+  return (state = initialState, action) => {
+    const { type, payload } = action
+
+    switch (type) {
+      case AuthorizationActionType.AUTHORIZATION_GRANT: {
+        console.log('grant', payload.features)
+
+        return {
+          ...state,
+          ...payload.features.reduce(
+            (acc, feature) => ({ ...acc, [feature]: true }),
+            {},
+          ),
+        }
+      }
+      case AuthorizationActionType.AUTHORIZATION_DENY: {
+        console.log('deny', payload.features)
+
+        return {
+          ...state,
+          ...payload.features.reduce(
+            (acc, feature) => ({ ...acc, [feature]: false }),
+            {},
+          ),
+        }
+      }
+      default: {
+        return state
+      }
+    }
+  }
+}

--- a/src/store/authorization.ts
+++ b/src/store/authorization.ts
@@ -46,8 +46,6 @@ export function getAuthorizationReducer(): AuthorizationReducer {
 
     switch (type) {
       case AuthorizationActionType.AUTHORIZATION_GRANT: {
-        console.log('grant', payload.features)
-
         return {
           ...state,
           ...payload.features.reduce(
@@ -57,8 +55,6 @@ export function getAuthorizationReducer(): AuthorizationReducer {
         }
       }
       case AuthorizationActionType.AUTHORIZATION_DENY: {
-        console.log('deny', payload.features)
-
         return {
           ...state,
           ...payload.features.reduce(

--- a/src/store/manager.ts
+++ b/src/store/manager.ts
@@ -17,6 +17,7 @@ import {
 
 import { StoreReducer } from './store'
 import { ConnectionAction, ConnectionActionType } from './connection'
+import { ConfidentialManager } from '@/domain/confidential'
 
 function createDefaultManagers(account?: Account) {
   const sdkClient = !account
@@ -45,6 +46,7 @@ export type ManagerState = {
   volumeManager?: VolumeManager
   programManager?: ProgramManager
   instanceManager?: InstanceManager
+  confidentialManager?: ConfidentialManager
   indexerManager?: IndexerManager
   websiteManager?: WebsiteManager
 }
@@ -82,6 +84,7 @@ export function getManagerReducer(): ManagerReducer {
           volumeManager: undefined,
           programManager: undefined,
           instanceManager: undefined,
+          confidentialManager: undefined,
           indexerManager: undefined,
           websiteManager: undefined,
         }
@@ -115,6 +118,15 @@ export function getManagerReducer(): ManagerReducer {
           fileManager,
           nodeManager,
         )
+        const confidentialManager = new ConfidentialManager(
+          account,
+          sdkClient,
+          volumeManager,
+          domainManager,
+          sshKeyManager,
+          fileManager,
+          nodeManager,
+        )
         const indexerManager = new IndexerManager(
           account,
           sdkClient,
@@ -137,6 +149,7 @@ export function getManagerReducer(): ManagerReducer {
           volumeManager,
           programManager,
           instanceManager,
+          confidentialManager,
           indexerManager,
           websiteManager,
         }

--- a/src/store/manager.ts
+++ b/src/store/manager.ts
@@ -18,6 +18,7 @@ import {
 import { StoreReducer } from './store'
 import { ConnectionAction, ConnectionActionType } from './connection'
 import { ConfidentialManager } from '@/domain/confidential'
+import { VoucherManager } from '@/domain/voucher'
 
 function createDefaultManagers(account?: Account) {
   const sdkClient = !account
@@ -49,6 +50,7 @@ export type ManagerState = {
   confidentialManager?: ConfidentialManager
   indexerManager?: IndexerManager
   websiteManager?: WebsiteManager
+  voucherManager?: VoucherManager
 }
 
 export const initialState: ManagerState = {
@@ -62,6 +64,7 @@ export const initialState: ManagerState = {
   instanceManager: undefined,
   indexerManager: undefined,
   websiteManager: undefined,
+  voucherManager: undefined,
 }
 
 export type ManagerAction = ConnectionAction
@@ -87,6 +90,7 @@ export function getManagerReducer(): ManagerReducer {
           confidentialManager: undefined,
           indexerManager: undefined,
           websiteManager: undefined,
+          voucherManager: undefined,
         }
       }
 
@@ -138,6 +142,7 @@ export function getManagerReducer(): ManagerReducer {
           volumeManager,
           domainManager,
         )
+        const voucherManager = new VoucherManager(account, sdkClient)
 
         return {
           ...state,
@@ -152,6 +157,7 @@ export function getManagerReducer(): ManagerReducer {
           confidentialManager,
           indexerManager,
           websiteManager,
+          voucherManager,
         }
       }
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -80,7 +80,7 @@ export const storeReducer = mergeReducers<StoreState>({
   // @note: refactor this entities
   programVolume: getEntityReducer<Volume>('programVolume', 'id'),
   instanceVolume: getEntityReducer<Volume>('instanceVolume', 'id'),
-  confidentialVolume: getEntityReducer<Volume>('instanceVolume', 'id'),
+  confidentialVolume: getEntityReducer<Volume>('confidentialVolume', 'id'),
 })
 
 export const storeInitialState: StoreState = getInitialState(storeReducer)

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -8,6 +8,7 @@ import { Volume } from '@/domain/volume'
 import { Website } from '@/domain/website'
 import { ManagerState, getManagerReducer } from './manager'
 import { Confidential } from '@/domain/confidential'
+import { AuthorizationState, getAuthorizationReducer } from './authorization'
 
 export type StoreSubstate = Record<string, unknown>
 
@@ -50,6 +51,7 @@ export function getInitialState<
 export type StoreState = {
   connection: ConnectionState
   manager: ManagerState
+  authorization: AuthorizationState
   ssh: EntityState<SSHKey>
   domain: EntityState<Domain>
   instance: EntityState<Instance>
@@ -66,6 +68,7 @@ export type StoreState = {
 export const storeReducer = mergeReducers<StoreState>({
   connection: getConnectionReducer(),
   manager: getManagerReducer(),
+  authorization: getAuthorizationReducer(),
   ssh: getEntityReducer<SSHKey>('ssh', 'id'),
   domain: getEntityReducer<Domain>('domain', 'id'),
   instance: getEntityReducer<Instance>('instance', 'id'),

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -7,6 +7,7 @@ import { Program } from '@/domain/program'
 import { Volume } from '@/domain/volume'
 import { Website } from '@/domain/website'
 import { ManagerState, getManagerReducer } from './manager'
+import { Confidential } from '@/domain/confidential'
 
 export type StoreSubstate = Record<string, unknown>
 
@@ -52,12 +53,14 @@ export type StoreState = {
   ssh: EntityState<SSHKey>
   domain: EntityState<Domain>
   instance: EntityState<Instance>
+  confidential: EntityState<Confidential>
   program: EntityState<Program>
   volume: EntityState<Volume>
   website: EntityState<Website>
 
   programVolume: EntityState<Volume>
   instanceVolume: EntityState<Volume>
+  confidentialVolume: EntityState<Volume>
 }
 
 export const storeReducer = mergeReducers<StoreState>({
@@ -66,6 +69,7 @@ export const storeReducer = mergeReducers<StoreState>({
   ssh: getEntityReducer<SSHKey>('ssh', 'id'),
   domain: getEntityReducer<Domain>('domain', 'id'),
   instance: getEntityReducer<Instance>('instance', 'id'),
+  confidential: getEntityReducer<Confidential>('confidential', 'id'),
   program: getEntityReducer<Program>('program', 'id'),
   volume: getEntityReducer<Volume>('volume', 'id'),
   website: getEntityReducer<Website>('website', 'id'),
@@ -73,6 +77,7 @@ export const storeReducer = mergeReducers<StoreState>({
   // @note: refactor this entities
   programVolume: getEntityReducer<Volume>('programVolume', 'id'),
   instanceVolume: getEntityReducer<Volume>('instanceVolume', 'id'),
+  confidentialVolume: getEntityReducer<Volume>('instanceVolume', 'id'),
 })
 
 export const storeInitialState: StoreState = getInitialState(storeReducer)


### PR DESCRIPTION
This PR includes:

- Confidential Instances Pages:
  - Dashboard
  - Manage (Details without action buttons)
- Possibility to manage authorization inside the app
  - Confidential features are only enabled to accounts with Confidentials or NFT that enable access to Confidentials (General or Confidential NFT)
- Main dashboard page Confidential Instances Entity Card info
- Modification in how status of computing entities is calculated in the home dashboard cards
- Multiple refactors
- Typos fixes