### PR TITLE
feat: Reduce persistent entities pricing

### DIFF
--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -135,7 +135,7 @@ export abstract class ExecutableManager {
       paymentMethod === PaymentMethod.Hold
         ? isPersistent
           ? 1_000
-          : 100
+          : 200
         : 0.055
 
     const capabilitiesCost = Object.values(capabilities).reduce(

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -132,7 +132,11 @@ export abstract class ExecutableManager {
     isPersistent = type === EntityType.Instance ? true : isPersistent
 
     const basePrice =
-      paymentMethod === PaymentMethod.Hold ? (isPersistent ? 2_000 : 200) : 0.11
+      paymentMethod === PaymentMethod.Hold
+        ? isPersistent
+          ? 1_000
+          : 100
+        : 0.055
 
     const capabilitiesCost = Object.values(capabilities).reduce(
       (ac, cv) => ac + Number(cv),

--- a/src/hooks/common/useEntityCost.ts
+++ b/src/hooks/common/useEntityCost.ts
@@ -29,17 +29,27 @@ export function useEntityCost({ entityType, props }: UseEntityCostProps) {
 
   useEffect(() => {
     async function load() {
-      const result = await (entityType === EntityType.Volume
-        ? VolumeManager.getCost(props as VolumeCostProps)
-        : entityType === EntityType.Instance
-          ? InstanceManager.getCost(props as InstanceCostProps)
-          : entityType === EntityType.Program
-            ? ProgramManager.getCost(props as ProgramCostProps)
-            : entityType === EntityType.Indexer
-              ? IndexerManager.getCost(props as IndexerCostProps)
-              : entityType === EntityType.Website
-                ? WebsiteManager.getCost(props as WebsiteCostProps)
-                : undefined)
+      let result
+
+      switch (entityType) {
+        case EntityType.Volume:
+          result = await VolumeManager.getCost(props as VolumeCostProps)
+          break
+        case EntityType.Instance:
+          result = await InstanceManager.getCost(props as InstanceCostProps)
+          break
+        case EntityType.Program:
+          result = await ProgramManager.getCost(props as ProgramCostProps)
+          break
+        case EntityType.Indexer:
+          result = await IndexerManager.getCost(props as IndexerCostProps)
+          break
+        case EntityType.Website:
+          result = await WebsiteManager.getCost(props as WebsiteCostProps)
+          break
+        default:
+          result = undefined
+      }
 
       setCost(result)
     }


### PR DESCRIPTION
### Task
https://aleph-im.atlassian.net/browse/ALEPH-293

### Description
As we released the confidential VMs we need to put the half pricing on normal instances and half of the flow price also, but remain confidentials as it is.

On the Console page we replicate the same cost logic than in pyaleph, so we also need to modify it as we are calculating the price before sending the message.