### PR TITLE
fix: wrong gpu default specs

### DIFF
--- a/src/components/form/SelectInstanceSpecs/cmp.tsx
+++ b/src/components/form/SelectInstanceSpecs/cmp.tsx
@@ -109,7 +109,7 @@ export const SelectInstanceSpecs = memo((props: SelectInstanceSpecsProps) => {
   // ------------------------------------------
 
   const [prices, setPrices] = useState<number[]>([])
-  const { cpu } = specsCtrl.field.value
+  const cpu = specsCtrl.field.value?.cpu
 
   const costManager = useCostManager()
 

--- a/src/components/form/SelectInstanceSpecs/cmp.tsx
+++ b/src/components/form/SelectInstanceSpecs/cmp.tsx
@@ -109,7 +109,7 @@ export const SelectInstanceSpecs = memo((props: SelectInstanceSpecsProps) => {
   // ------------------------------------------
 
   const [prices, setPrices] = useState<number[]>([])
-  const cpu = specsCtrl.field.value?.cpu
+  const { cpu } = specsCtrl.field.value || {}
 
   const costManager = useCostManager()
 

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -583,8 +583,8 @@ export abstract class ExecutableManager<T extends Executable> {
 
   protected parseSpecs(
     specs: InstanceSpecsField,
-  ): Omit<MachineResources, 'seconds'> | object {
-    if (!specs) return {}
+  ): Omit<MachineResources, 'seconds'> | undefined {
+    if (!specs) return
 
     return {
       vcpus: specs.cpu,

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -583,7 +583,9 @@ export abstract class ExecutableManager<T extends Executable> {
 
   protected parseSpecs(
     specs: InstanceSpecsField,
-  ): Omit<MachineResources, 'seconds'> {
+  ): Omit<MachineResources, 'seconds'> | object {
+    if (!specs) return {}
+
     return {
       vcpus: specs.cpu,
       memory: specs.ram,

--- a/src/domain/gpuInstance.ts
+++ b/src/domain/gpuInstance.ts
@@ -52,7 +52,7 @@ export class GpuInstanceManager extends InstanceManager<GpuInstance> {
 
   protected override parseMessagesFilter({ content }: any): boolean {
     if (content === undefined) return false
-
+    return true
     return content.requirements?.gpu?.length
   }
 

--- a/src/domain/gpuInstance.ts
+++ b/src/domain/gpuInstance.ts
@@ -52,7 +52,7 @@ export class GpuInstanceManager extends InstanceManager<GpuInstance> {
 
   protected override parseMessagesFilter({ content }: any): boolean {
     if (content === undefined) return false
-    return true
+
     return content.requirements?.gpu?.length
   }
 

--- a/src/domain/program.ts
+++ b/src/domain/program.ts
@@ -322,7 +322,10 @@ export class ProgramManager
 
     const { isPersistent, specs } = newProgram
 
-    const { memory, vcpus } = this.parseSpecs(specs)
+    const parsedSpecs = this.parseSpecs(specs)
+    const memory = parsedSpecs?.memory
+    const vcpus = parsedSpecs?.vcpus
+
     const runtime = this.parseRuntime(newProgram)
     const payment = this.parsePayment(newProgram.payment)
     const volumesSteps = this.parseVolumesSteps(newProgram.volumes, true)
@@ -364,7 +367,11 @@ export class ProgramManager
     const { name, tags, isPersistent, envVars, specs } = newProgram
 
     const variables = this.parseEnvVars(envVars)
-    const { memory, vcpus } = this.parseSpecs(specs)
+
+    const parsedSpecs = this.parseSpecs(specs)
+    const memory = parsedSpecs?.memory
+    const vcpus = parsedSpecs?.vcpus
+
     const metadata = this.parseMetadata(name, tags, newProgram.metadata)
     const runtime = this.parseRuntime(newProgram)
     const payment = this.parsePayment(newProgram.payment)

--- a/src/domain/program.ts
+++ b/src/domain/program.ts
@@ -368,9 +368,7 @@ export class ProgramManager
 
     const variables = this.parseEnvVars(envVars)
 
-    const parsedSpecs = this.parseSpecs(specs)
-    const memory = parsedSpecs?.memory
-    const vcpus = parsedSpecs?.vcpus
+    const { memory, vcpus } = this.parseSpecs(specs) || {}
 
     const metadata = this.parseMetadata(name, tags, newProgram.metadata)
     const runtime = this.parseRuntime(newProgram)

--- a/src/hooks/pages/computing/useNewGpuInstancePage.ts
+++ b/src/hooks/pages/computing/useNewGpuInstancePage.ts
@@ -279,7 +279,7 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
     () => ({
       ...defaultNameAndTags,
       image: defaultInstanceImage,
-      specs: defaultTiers[0],
+      specs: undefined,
       systemVolumeSize: defaultTiers[0]?.storage,
       paymentMethod: PaymentMethod.Stream,
       streamDuration: defaultStreamDuration,
@@ -305,7 +305,8 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
 
   // -------------------------
 
-  const { storage } = formValues.specs
+  const storage = formValues.specs?.storage
+
   const { systemVolumeSize } = formValues
 
   const payment: PaymentConfiguration = useMemo(() => {
@@ -319,6 +320,7 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
     } as PaymentConfiguration
   }, [formValues, blockchain, account, node])
 
+  console.log('formValues', formValues)
   const costProps: UseGpuInstanceCostProps = useMemo(
     () => ({
       entityType: EntityType.GpuInstance,

--- a/src/hooks/pages/computing/useNewGpuInstancePage.ts
+++ b/src/hooks/pages/computing/useNewGpuInstancePage.ts
@@ -320,7 +320,6 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
     } as PaymentConfiguration
   }, [formValues, blockchain, account, node])
 
-  console.log('formValues', formValues)
   const costProps: UseGpuInstanceCostProps = useMemo(
     () => ({
       entityType: EntityType.GpuInstance,

--- a/src/hooks/pages/computing/useNewGpuInstancePage.ts
+++ b/src/hooks/pages/computing/useNewGpuInstancePage.ts
@@ -305,7 +305,7 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
 
   // -------------------------
 
-  const storage = formValues.specs?.storage
+  const { storage } = formValues.specs || {}
 
   const { systemVolumeSize } = formValues
 


### PR DESCRIPTION
When creating a new GPU instance it was setting by default the hardcoded tier and it was allowing the user to create gpu with lower resources.

Fixed by setting the default specs empty instead.