### PR TITLE
Feat: Auto-select first available tier when CRN node is selected in PAYG mode

### DIFF
--- a/src/hooks/form/useSelectInstanceSpecs.ts
+++ b/src/hooks/form/useSelectInstanceSpecs.ts
@@ -79,6 +79,19 @@ export function useSelectInstanceSpecs({
 
   const { value, onChange } = specsCtrl.field
 
+  // Auto select first available tier when CRN node is selected in PAYG mode
+  useEffect(() => {
+    // Only apply for PAYG payment method when we have valid options and node specs
+    if (paymentMethod === PaymentMethod.Stream && nodeSpecs && options.length > 0) {
+      // If no tier is selected yet or the current selected tier is not compatible
+      // with the selected node, auto-select the first available tier
+      if (!value || (nodeSpecs && !manager.validateMinNodeSpecs(value, nodeSpecs))) {
+        const firstAvailableTier = options[0]
+        onChange(updateSpecsStorage(firstAvailableTier, isPersistent, paymentMethod))
+      }
+    }
+  }, [options, nodeSpecs, paymentMethod, isPersistent, value, onChange, manager])
+
   useEffect(() => {
     if (!value) return
 


### PR DESCRIPTION
 ## Summary
  - Add automatic selection of the first available tier when a CRN node is selected in PAYG mode
  - This improves user experience by reducing the number of required actions in the form flow
  - The change only applies to GPU Instance and regular Instance PAYG creation workflows

  ## Test plan
  - Open the Instance creation form and select PAYG payment method
  - Select a CRN node and verify the first compatible tier is automatically selected
  - Open the GPU Instance creation form
  - Select a GPU node and verify the first compatible tier is automatically selected