### PR TITLE
Feat: Add info icons to disabled buttons with tooltips

### DIFF
--- a/src/components/common/ButtonWithInfoTooltip/cmp.tsx
+++ b/src/components/common/ButtonWithInfoTooltip/cmp.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef, useState } from 'react'
+import React, { forwardRef, useEffect, useRef, useState, useMemo } from 'react'
 import { Button, ButtonProps, Icon } from '@aleph-front/core'
 import ResponsiveTooltip from '../ResponsiveTooltip'
 
@@ -20,7 +20,14 @@ export const ButtonWithInfoTooltip = forwardRef<
   ButtonWithInfoTooltipProps
 >(
   (
-    { tooltipContent, tooltipPosition, children, disabled, ...buttonProps },
+    {
+      tooltipContent,
+      tooltipPosition,
+      children,
+      disabled,
+      size,
+      ...buttonProps
+    },
     ref,
   ) => {
     // Wait until after client-side hydration to show tooltip
@@ -29,17 +36,44 @@ export const ButtonWithInfoTooltip = forwardRef<
       setRenderTooltip(true)
     }, [])
 
+    // Determine icon size based on button size
+    const iconSize = useMemo(() => {
+      switch (size) {
+        case 'xs':
+          return 'xs'
+        case 'sm':
+          return 'sm'
+        case 'md':
+          return 'md'
+        case 'lg':
+          return 'md' // Slightly larger relative to button
+        case 'xl':
+          return 'lg'
+        default:
+          return 'md'
+      }
+    }, [size])
+
     // Create a ref if one wasn't provided
     const buttonRef = useRef<HTMLButtonElement>(null)
     const targetRef = (ref as React.RefObject<HTMLButtonElement>) || buttonRef
 
     return (
       <div className="inline-flex relative">
-        <Button ref={targetRef} disabled={disabled} {...buttonProps}>
-          <span className="flex items-center gap-2">
+        <Button
+          ref={targetRef}
+          disabled={disabled}
+          size={size}
+          {...buttonProps}
+        >
+          <span className="flex items-center gap-3">
             {children}
             {disabled && tooltipContent && (
-              <Icon name="info-circle" size="sm" style={{ opacity: 0.8 }} />
+              <Icon
+                name="info-circle"
+                size={iconSize}
+                style={{ opacity: 0.8 }}
+              />
             )}
           </span>
         </Button>

--- a/src/components/common/ButtonWithInfoTooltip/cmp.tsx
+++ b/src/components/common/ButtonWithInfoTooltip/cmp.tsx
@@ -49,12 +49,12 @@ export const ButtonWithInfoTooltip = forwardRef<
           size={size}
           {...buttonProps}
         >
-          <span className="flex items-center gap-3">
+          <>
             {children}
             {disabled && tooltipContent && (
               <InfoIcon name="info-circle" buttonSize={size} />
             )}
-          </span>
+          </>
         </Button>
 
         {renderTooltip && disabled && tooltipContent && (

--- a/src/components/common/ButtonWithInfoTooltip/cmp.tsx
+++ b/src/components/common/ButtonWithInfoTooltip/cmp.tsx
@@ -1,14 +1,11 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react'
-import { Button, ButtonProps } from '@aleph-front/core'
+import { Button, ButtonProps, TooltipProps } from '@aleph-front/core'
 import ResponsiveTooltip from '../ResponsiveTooltip'
 import { InfoIcon } from './styles'
 
 export type ButtonWithInfoTooltipProps = ButtonProps & {
   tooltipContent?: React.ReactNode
-  tooltipPosition?: {
-    my?: string
-    at?: string
-  }
+  tooltipPosition?: Pick<TooltipProps, 'my' | 'at'>
 }
 
 /**

--- a/src/components/common/ButtonWithInfoTooltip/cmp.tsx
+++ b/src/components/common/ButtonWithInfoTooltip/cmp.tsx
@@ -1,0 +1,62 @@
+import React, { forwardRef, useEffect, useRef, useState } from 'react'
+import { Button, ButtonProps, Icon } from '@aleph-front/core'
+import ResponsiveTooltip from '../ResponsiveTooltip'
+
+export type ButtonWithInfoTooltipProps = ButtonProps & {
+  tooltipContent?: React.ReactNode
+  tooltipPosition?: {
+    my?: string
+    at?: string
+  }
+}
+
+/**
+ * Extended Button component that shows an info icon with tooltip when disabled
+ * This component automatically adds the info icon to disabled buttons
+ * and shows the tooltip when hovering over the button or icon
+ */
+export const ButtonWithInfoTooltip = forwardRef<
+  HTMLButtonElement,
+  ButtonWithInfoTooltipProps
+>(
+  (
+    { tooltipContent, tooltipPosition, children, disabled, ...buttonProps },
+    ref,
+  ) => {
+    // Wait until after client-side hydration to show tooltip
+    const [renderTooltip, setRenderTooltip] = useState(false)
+    useEffect(() => {
+      setRenderTooltip(true)
+    }, [])
+
+    // Create a ref if one wasn't provided
+    const buttonRef = useRef<HTMLButtonElement>(null)
+    const targetRef = (ref as React.RefObject<HTMLButtonElement>) || buttonRef
+
+    return (
+      <div className="inline-flex relative">
+        <Button ref={targetRef} disabled={disabled} {...buttonProps}>
+          <span className="flex items-center gap-2">
+            {children}
+            {disabled && tooltipContent && (
+              <Icon name="info-circle" size="sm" style={{ opacity: 0.8 }} />
+            )}
+          </span>
+        </Button>
+
+        {renderTooltip && disabled && tooltipContent && (
+          <ResponsiveTooltip
+            my={tooltipPosition?.my || 'bottom-center'}
+            at={tooltipPosition?.at || 'top-center'}
+            targetRef={targetRef}
+            content={tooltipContent}
+          />
+        )}
+      </div>
+    )
+  },
+)
+
+ButtonWithInfoTooltip.displayName = 'ButtonWithInfoTooltip'
+
+export default ButtonWithInfoTooltip

--- a/src/components/common/ButtonWithInfoTooltip/cmp.tsx
+++ b/src/components/common/ButtonWithInfoTooltip/cmp.tsx
@@ -1,6 +1,7 @@
-import React, { forwardRef, useEffect, useRef, useState, useMemo } from 'react'
-import { Button, ButtonProps, Icon } from '@aleph-front/core'
+import React, { forwardRef, useEffect, useRef, useState } from 'react'
+import { Button, ButtonProps } from '@aleph-front/core'
 import ResponsiveTooltip from '../ResponsiveTooltip'
+import { InfoIcon } from './styles'
 
 export type ButtonWithInfoTooltipProps = ButtonProps & {
   tooltipContent?: React.ReactNode
@@ -36,24 +37,6 @@ export const ButtonWithInfoTooltip = forwardRef<
       setRenderTooltip(true)
     }, [])
 
-    // Determine icon size based on button size
-    const iconSize = useMemo(() => {
-      switch (size) {
-        case 'xs':
-          return 'xs'
-        case 'sm':
-          return 'sm'
-        case 'md':
-          return 'md'
-        case 'lg':
-          return 'md' // Slightly larger relative to button
-        case 'xl':
-          return 'lg'
-        default:
-          return 'md'
-      }
-    }, [size])
-
     // Create a ref if one wasn't provided
     const buttonRef = useRef<HTMLButtonElement>(null)
     const targetRef = (ref as React.RefObject<HTMLButtonElement>) || buttonRef
@@ -69,11 +52,7 @@ export const ButtonWithInfoTooltip = forwardRef<
           <span className="flex items-center gap-3">
             {children}
             {disabled && tooltipContent && (
-              <Icon
-                name="info-circle"
-                size={iconSize}
-                style={{ opacity: 0.8 }}
-              />
+              <InfoIcon name="info-circle" buttonSize={size} />
             )}
           </span>
         </Button>

--- a/src/components/common/ButtonWithInfoTooltip/index.ts
+++ b/src/components/common/ButtonWithInfoTooltip/index.ts
@@ -1,0 +1,4 @@
+import ButtonWithInfoTooltip from './cmp'
+
+export default ButtonWithInfoTooltip
+export * from './cmp'

--- a/src/components/common/ButtonWithInfoTooltip/index.ts
+++ b/src/components/common/ButtonWithInfoTooltip/index.ts
@@ -2,3 +2,4 @@ import ButtonWithInfoTooltip from './cmp'
 
 export default ButtonWithInfoTooltip
 export * from './cmp'
+export * from './styles'

--- a/src/components/common/ButtonWithInfoTooltip/styles.tsx
+++ b/src/components/common/ButtonWithInfoTooltip/styles.tsx
@@ -5,22 +5,22 @@ type InfoIconProps = IconProps & {
   buttonSize?: string
 }
 
-export const InfoIcon = styled(Icon)<InfoIconProps>`
-  opacity: 0.8;
-
-  ${({ buttonSize }) => {
+export const InfoIcon = styled(Icon).attrs<InfoIconProps>(({ buttonSize }) => ({
+  size: (() => {
     switch (buttonSize) {
       case 'xs':
-        return 'font-size: 0.75rem;' // xs
+        return 'xs' // xs
       case 'sm':
-        return 'font-size: 0.875rem;' // sm
+        return 'sm' // sm
       case 'lg':
-        return 'font-size: 1.25rem;' // md-lg
+        return 'md-lg' // md-lg
       case 'xl':
-        return 'font-size: 1.5rem;' // lg
+        return 'lg' // lg
       case 'md':
       default:
-        return 'font-size: 1rem;' // md
+        return 'md' // md
     }
-  }}
+  })(),
+}))<InfoIconProps>`
+  opacity: 0.8;
 `

--- a/src/components/common/ButtonWithInfoTooltip/styles.tsx
+++ b/src/components/common/ButtonWithInfoTooltip/styles.tsx
@@ -1,0 +1,26 @@
+import { Icon, IconProps } from '@aleph-front/core'
+import styled from 'styled-components'
+
+type InfoIconProps = IconProps & {
+  buttonSize?: string
+}
+
+export const InfoIcon = styled(Icon)<InfoIconProps>`
+  opacity: 0.8;
+
+  ${({ buttonSize }) => {
+    switch (buttonSize) {
+      case 'xs':
+        return 'font-size: 0.75rem;' // xs
+      case 'sm':
+        return 'font-size: 0.875rem;' // sm
+      case 'lg':
+        return 'font-size: 1.25rem;' // md-lg
+      case 'xl':
+        return 'font-size: 1.5rem;' // lg
+      case 'md':
+      default:
+        return 'font-size: 1rem;' // md
+    }
+  }}
+`

--- a/src/components/pages/computing/NewGpuInstancePage/cmp.tsx
+++ b/src/components/pages/computing/NewGpuInstancePage/cmp.tsx
@@ -11,6 +11,7 @@ import {
   TooltipProps,
   Checkbox,
 } from '@aleph-front/core'
+import ButtonWithInfoTooltip from '@/components/common/ButtonWithInfoTooltip'
 import { CRNSpecs } from '@/domain/node'
 import SelectInstanceImage from '@/components/form/SelectInstanceImage'
 import SelectInstanceSpecs from '@/components/form/SelectInstanceSpecs'
@@ -36,7 +37,6 @@ import { PageProps } from '@/types/types'
 import Strong from '@/components/common/Strong'
 import CRNList from '../../../common/CRNList'
 import BackButtonSection from '@/components/common/BackButtonSection'
-import ResponsiveTooltip from '@/components/common/ResponsiveTooltip'
 import BorderBox from '@/components/common/BorderBox'
 import ExternalLink from '@/components/common/ExternalLink'
 import {
@@ -65,32 +65,27 @@ const CheckoutButton = React.memo(
     const checkoutButtonRef = useRef<HTMLButtonElement>(null)
 
     return (
-      <>
-        <Button
-          ref={checkoutButtonRef}
-          type={shouldRequestTermsAndConditions ? 'button' : 'submit'}
-          color="main0"
-          kind="default"
-          size="lg"
-          variant="primary"
-          disabled={disabled}
-          onClick={
-            shouldRequestTermsAndConditions
-              ? handleRequestTermsAndConditionsAgreement
-              : handleSubmit
-          }
-        >
-          {title}
-        </Button>
-        {tooltipContent && (
-          <ResponsiveTooltip
-            my={isFooter ? 'bottom-right' : 'bottom-center'}
-            at={isFooter ? 'top-right' : 'top-center'}
-            targetRef={checkoutButtonRef}
-            content={tooltipContent}
-          />
-        )}
-      </>
+      <ButtonWithInfoTooltip
+        ref={checkoutButtonRef}
+        type={shouldRequestTermsAndConditions ? 'button' : 'submit'}
+        color="main0"
+        kind="default"
+        size="lg"
+        variant="primary"
+        disabled={disabled}
+        tooltipContent={tooltipContent}
+        tooltipPosition={{
+          my: isFooter ? 'bottom-right' : 'bottom-center',
+          at: isFooter ? 'top-right' : 'top-center',
+        }}
+        onClick={
+          shouldRequestTermsAndConditions
+            ? handleRequestTermsAndConditionsAgreement
+            : handleSubmit
+        }
+      >
+        {title}
+      </ButtonWithInfoTooltip>
     )
   },
 )
@@ -337,7 +332,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
                 <div tw="mt-6">
                   {!node && (
                     <>
-                      <Button
+                      <ButtonWithInfoTooltip
                         ref={manuallySelectButtonRef}
                         type="button"
                         kind="functional"
@@ -346,7 +341,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
                         onClick={handleManuallySelectCRN}
                       >
                         Manually select GPU
-                      </Button>
+                      </ButtonWithInfoTooltip>
                     </>
                   )}
                 </div>

--- a/src/components/pages/computing/NewInstancePage/cmp.tsx
+++ b/src/components/pages/computing/NewInstancePage/cmp.tsx
@@ -12,6 +12,7 @@ import {
   TooltipProps,
   Checkbox,
 } from '@aleph-front/core'
+import ButtonWithInfoTooltip from '@/components/common/ButtonWithInfoTooltip'
 import { CRNSpecs } from '@/domain/node'
 import SelectInstanceImage from '@/components/form/SelectInstanceImage'
 import SelectInstanceSpecs from '@/components/form/SelectInstanceSpecs'
@@ -41,7 +42,6 @@ import { PageProps } from '@/types/types'
 import Strong from '@/components/common/Strong'
 import CRNList from '../../../common/CRNList'
 import BackButtonSection from '@/components/common/BackButtonSection'
-import ResponsiveTooltip from '@/components/common/ResponsiveTooltip'
 import BorderBox from '@/components/common/BorderBox'
 import ExternalLink from '@/components/common/ExternalLink'
 
@@ -66,32 +66,27 @@ const CheckoutButton = React.memo(
     const checkoutButtonRef = useRef<HTMLButtonElement>(null)
 
     return (
-      <>
-        <Button
-          ref={checkoutButtonRef}
-          type={shouldRequestTermsAndConditions ? 'button' : 'submit'}
-          color="main0"
-          kind="default"
-          size="lg"
-          variant="primary"
-          disabled={disabled}
-          onClick={
-            shouldRequestTermsAndConditions
-              ? handleRequestTermsAndConditionsAgreement
-              : handleSubmit
-          }
-        >
-          {title}
-        </Button>
-        {tooltipContent && (
-          <ResponsiveTooltip
-            my={isFooter ? 'bottom-right' : 'bottom-center'}
-            at={isFooter ? 'top-right' : 'top-center'}
-            targetRef={checkoutButtonRef}
-            content={tooltipContent}
-          />
-        )}
-      </>
+      <ButtonWithInfoTooltip
+        ref={checkoutButtonRef}
+        type={shouldRequestTermsAndConditions ? 'button' : 'submit'}
+        color="main0"
+        kind="default"
+        size="lg"
+        variant="primary"
+        disabled={disabled}
+        tooltipContent={tooltipContent}
+        tooltipPosition={{
+          my: isFooter ? 'bottom-right' : 'bottom-center',
+          at: isFooter ? 'top-right' : 'top-center',
+        }}
+        onClick={
+          shouldRequestTermsAndConditions
+            ? handleRequestTermsAndConditionsAgreement
+            : handleSubmit
+        }
+      >
+        {title}
+      </ButtonWithInfoTooltip>
     )
   },
 )
@@ -349,7 +344,7 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                   <div tw="mt-6">
                     {!node && (
                       <>
-                        <Button
+                        <ButtonWithInfoTooltip
                           ref={manuallySelectButtonRef}
                           type="button"
                           kind="functional"
@@ -357,17 +352,14 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                           size="md"
                           onClick={handleManuallySelectCRN}
                           disabled={manuallySelectCRNDisabled}
+                          tooltipContent={manuallySelectCRNDisabledMessage}
+                          tooltipPosition={{
+                            my: 'bottom-left',
+                            at: 'center-center',
+                          }}
                         >
                           Manually select CRN
-                        </Button>
-                        {manuallySelectCRNDisabledMessage && (
-                          <ResponsiveTooltip
-                            my="bottom-left"
-                            at="center-center"
-                            targetRef={manuallySelectButtonRef}
-                            content={manuallySelectCRNDisabledMessage}
-                          />
-                        )}
+                        </ButtonWithInfoTooltip>
                       </>
                     )}
                   </div>
@@ -411,7 +403,7 @@ export default function NewInstancePage({ mainRef }: PageProps) {
               >
                 {values.paymentMethod !== PaymentMethod.Stream ? (
                   <div tw="mt-6">
-                    <Button
+                    <ButtonWithInfoTooltip
                       ref={manuallySelectButtonRef2}
                       type="button"
                       kind="functional"
@@ -419,17 +411,14 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                       size="md"
                       disabled={manuallySelectCRNDisabled}
                       onClick={handleManuallySelectCRN}
+                      tooltipContent={manuallySelectCRNDisabledMessage}
+                      tooltipPosition={{
+                        my: 'bottom-left',
+                        at: 'center-center',
+                      }}
                     >
                       Manually select CRN
-                    </Button>
-                    {manuallySelectCRNDisabledMessage && (
-                      <ResponsiveTooltip
-                        my="bottom-left"
-                        at="center-center"
-                        targetRef={manuallySelectButtonRef2}
-                        content={manuallySelectCRNDisabledMessage}
-                      />
-                    )}
+                    </ButtonWithInfoTooltip>
                   </div>
                 ) : (
                   !node && (


### PR DESCRIPTION
## Summary
  This PR adds a feature that displays an info icon in disabled buttons when there's a tooltip explaining why the button is disabled.

  ## Changes
  - Created a new `ButtonWithInfoTooltip` component that automatically shows an info icon when a button is disabled and has tooltip content
  - Implemented the new component in checkout buttons and "manually select CRN/GPU" buttons in instance creation forms
  - Ensures that tooltips are properly positioned and only shown when a button is disabled and has explanation content
  - Removed redundant tooltip code and cleaned up imports

  ## Testing
  To test this feature:
  1. Navigate to the Instance creation or GPU Instance creation pages
  2. Check for cases where buttons are disabled (e.g., "Manually select CRN" when not appropriate)
  3. Verify that an info icon appears on the disabled button
  4. Hover over the info icon to see the tooltip with the explanation
  5. Confirm that buttons without explanations don't show an info icon when disabled

  The PR is creating a new component that helps provide consistent visual feedback to users about why buttons are disabled, improving the UX by making the reasons for disabled
  functionality more discoverable.