### PR TITLE
Fix: Add volume name validation to allow only alphanumeric, underscore, and dash characters

### DIFF
--- a/src/helpers/schemas/base.ts
+++ b/src/helpers/schemas/base.ts
@@ -14,6 +14,14 @@ export const requiredRestrictedStringSchema = requiredStringSchema.regex(
   },
 )
 
+export const requiredVolumeNameSchema = requiredStringSchema.regex(
+  /^[a-zA-Z0-9_-]+$/,
+  {
+    message:
+      'Volume name can only contain letters, numbers, underscores, and dashes',
+  },
+)
+
 export function optionalString(schema: z.ZodString) {
   return schema.optional().or(z.literal(''))
 }

--- a/src/helpers/schemas/execution.ts
+++ b/src/helpers/schemas/execution.ts
@@ -6,6 +6,7 @@ import {
   optionalStringSchema,
   requiredStringSchema,
   requiredRestrictedStringSchema,
+  requiredVolumeNameSchema,
 } from './base'
 import { domainSchema } from './domain'
 import { newIsolatedVolumeSchema } from './volume'
@@ -28,7 +29,7 @@ export const existingVolumeSchema = z.object({
 
 export const persistentVolumeSchema = z.object({
   volumeType: z.literal(VolumeType.Persistent),
-  name: requiredStringSchema,
+  name: requiredVolumeNameSchema,
   mountPath: linuxPathSchema,
   size: z.number().gt(0),
 })


### PR DESCRIPTION
## Summary
  This PR adds validation to the volume name field in the volume creation form to only allow alphanumeric characters, underscores, and dashes.

  ## Changes
  - Created a new schema `requiredVolumeNameSchema` in base.ts with a specific error message
  - Updated the `persistentVolumeSchema` in execution.ts to use the new validation
  - Added regex pattern `/^[a-zA-Z0-9_-]+$/` for validation
  - Added a descriptive error message: "Volume name can only contain letters, numbers, underscores, and dashes"

  ## Testing
  - Try to create a new persistent volume with:
    - Valid name (e.g. "my-volume_123"): should work
    - Name with special characters (e.g. "test!volume"): should show validation error
    - Name with spaces (e.g. "test volume"): should show validation error