### PR TITLE
Fix: Restrict mount path validation to alphanumeric, underscores, and dashes

### DIFF
--- a/src/helpers/schemas/base.ts
+++ b/src/helpers/schemas/base.ts
@@ -39,9 +39,14 @@ export const urlSchema = requiredStringSchema.regex(
   { message: 'Invalid url format' },
 )
 
-export const linuxPathSchema = requiredStringSchema.regex(/^(\/[^\/ ]*)+\/?$/, {
-  message: 'Invalid path format',
-})
+export const linuxPathSchema = requiredStringSchema
+  .regex(/^(\/[^\/ ]*)+\/?$/, {
+    message: 'Invalid path format',
+  })
+  .regex(/^(\/[a-zA-Z0-9_-]*)+\/?$/, {
+    message:
+      'Mount path can only contain alphanumeric characters, underscores, and dashes',
+  })
 
 export const ethereumAddressSchema = requiredStringSchema.regex(
   /^0x[a-fA-F0-9]{40}$/,


### PR DESCRIPTION
  ## Summary
  - Updates the Linux path validation schema to restrict mount paths to only contain alphanumeric characters, underscores, and dashes
  - Maintains the existing path structure validation (must start with / and have proper format)
  - Provides a clear error message when invalid characters are used

  ## Test plan
  - Try to create a volume with mount path containing invalid characters (like spaces, special characters)
  - Verify valid mount paths (with alphanumeric, underscores, dashes) work correctly
  - Test paths with multiple segments (e.g., /data/files)