### PR TITLE
Fix: Correct GPU instance pricing calculation

### DIFF
--- a/src/domain/gpuInstance.ts
+++ b/src/domain/gpuInstance.ts
@@ -78,4 +78,24 @@ export class GpuInstanceManager extends InstanceManager<GpuInstance> {
       ],
     }
   }
+
+  protected override async parseInstanceForCostEstimation(
+    newInstance: AddInstance,
+  ): Promise<any> {
+    // Get the base instance configuration from the parent class
+    const baseInstanceConfig = await super.parseInstanceForCostEstimation(
+      newInstance,
+    )
+
+    // Add GPU requirements if a node with GPU is selected
+    if (newInstance.node?.selectedGpu) {
+      const gpuRequirements = this.parseRequirements(newInstance.node)
+      return {
+        ...baseInstanceConfig,
+        requirements: gpuRequirements,
+      }
+    }
+
+    return baseInstanceConfig
+  }
 }


### PR DESCRIPTION
## Summary
  - Fixes an issue where GPU instance pricing was incorrectly showing standard instance pricing
  - Overrides the `parseInstanceForCostEstimation` method in the GpuInstanceManager to properly include GPU requirements when estimating costs
  - Ensures GPU-specific pricing (e.g., L40S at 3.33 $ALEPH/h) is correctly displayed instead of standard pricing (0.6 $ALEPH/h)

  ## Test plan
  - Create a new GPU instance and select an L40S GPU
  - Verify the pricing shown is 3.33 $ALEPH/h instead of 0.6 $ALEPH/h
  - Test with other GPU types to ensure their pricing is correctly displayed