### PR TITLE
Fix: correctly account for system volume price in cost calculation

### DIFF
--- a/src/components/form/CheckoutSummary/cmp.tsx
+++ b/src/components/form/CheckoutSummary/cmp.tsx
@@ -275,7 +275,7 @@ export const CheckoutSummary = ({
                     <div>{line.detail}</div>
                     <div>
                       <span className="text-main0 tp-body3">
-                        {line.cost > 0 ? (
+                        {line.cost !== 0 ? (
                           <Price
                             value={line.cost}
                             duration={

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -787,24 +787,21 @@ export abstract class ExecutableManager<T extends Executable> {
 
     // Calculate the correct cost, including rootfs volume if applicable
     let executionCost = Number(detailMap[MessageCostType.EXECUTION][costProp])
-    
+
     // If we have a rootfs volume cost, add it to the execution cost
     if (rootfsVolume) {
       executionCost += Number(rootfsVolume[costProp])
     }
-    
+
     const executionLines = [
       {
         id: MessageCostType.EXECUTION,
         name: EntityTypeName[entityProps.type].toUpperCase(),
         detail,
-        cost: this.parseCost(
-          paymentMethod,
-          executionCost
-        ),
+        cost: this.parseCost(paymentMethod, executionCost),
       },
     ]
-    
+
     // Add volume discount line if it exists
     const volumeDiscount = detailMap[MessageCostType.EXECUTION_VOLUME_DISCOUNT]
     if (volumeDiscount) {
@@ -814,7 +811,7 @@ export abstract class ExecutableManager<T extends Executable> {
         detail: 'Applied discount for bundled storage',
         cost: this.parseCost(
           paymentMethod,
-          -Math.abs(Number(volumeDiscount[costProp])) // Ensure it's always negative
+          -Math.abs(Number(volumeDiscount[costProp])), // Ensure it's always negative
         ),
       })
     }

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -128,6 +128,9 @@ export const KEYPAIR_TTL = 1000 * 60 * 60 * 2
 export type ExecutableCostProps = (
   | {
       type: EntityType.Instance | EntityType.GpuInstance
+      rootfs?: {
+        size_mib?: number
+      }
     }
   | {
       type: EntityType.Program
@@ -755,11 +758,14 @@ export abstract class ExecutableManager<T extends Executable> {
 
     const rootfsVolume =
       detailMap[MessageCostType.EXECUTION_INSTANCE_VOLUME_ROOTFS]
-    const storage = rootfsVolume
-      ? ram * 10 > MAXIMUM_DISK_SIZE
-        ? MAXIMUM_DISK_SIZE
-        : ram * 10
-      : undefined
+
+    // Use the actual system volume size from rootfs
+    const storage =
+      rootfsVolume &&
+      entityProps.type !== EntityType.Program &&
+      entityProps.rootfs?.size_mib
+        ? entityProps.rootfs.size_mib
+        : undefined
 
     const storageStr = !storage
       ? ''
@@ -779,6 +785,14 @@ export abstract class ExecutableManager<T extends Executable> {
     const costProp =
       paymentMethod === PaymentMethod.Hold ? 'cost_hold' : 'cost_stream'
 
+    // Calculate the correct cost, including rootfs volume if applicable
+    let executionCost = Number(detailMap[MessageCostType.EXECUTION][costProp])
+    
+    // If we have a rootfs volume cost, add it to the execution cost
+    if (rootfsVolume) {
+      executionCost += Number(rootfsVolume[costProp])
+    }
+    
     const executionLines = [
       {
         id: MessageCostType.EXECUTION,
@@ -786,10 +800,24 @@ export abstract class ExecutableManager<T extends Executable> {
         detail,
         cost: this.parseCost(
           paymentMethod,
-          Number(detailMap[MessageCostType.EXECUTION][costProp]),
+          executionCost
         ),
       },
     ]
+    
+    // Add volume discount line if it exists
+    const volumeDiscount = detailMap[MessageCostType.EXECUTION_VOLUME_DISCOUNT]
+    if (volumeDiscount) {
+      executionLines.push({
+        id: MessageCostType.EXECUTION_VOLUME_DISCOUNT,
+        name: 'VOLUME DISCOUNT',
+        detail: 'Applied discount for bundled storage',
+        cost: this.parseCost(
+          paymentMethod,
+          Number(volumeDiscount[costProp])
+        ),
+      })
+    }
 
     // Volumes
 

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -814,7 +814,7 @@ export abstract class ExecutableManager<T extends Executable> {
         detail: 'Applied discount for bundled storage',
         cost: this.parseCost(
           paymentMethod,
-          Number(volumeDiscount[costProp])
+          -Math.abs(Number(volumeDiscount[costProp])) // Ensure it's always negative
         ),
       })
     }

--- a/src/helpers/schemas/instance.ts
+++ b/src/helpers/schemas/instance.ts
@@ -117,10 +117,11 @@ export const streamDurationSchema = z.object({
 })
 
 export const systemVolumeSchema = z.object({
-  size: z.number()
+  size: z
+    .number()
     .gt(0, { message: 'System volume size must be greater than 0' })
-    .lte(MAXIMUM_DISK_SIZE, { 
-      message: `System volume size cannot exceed ${MAXIMUM_DISK_SIZE} MiB (${Math.round(MAXIMUM_DISK_SIZE/1024)} GiB)` 
+    .lte(MAXIMUM_DISK_SIZE, {
+      message: `System volume size cannot exceed ${MAXIMUM_DISK_SIZE} MiB (${Math.round(MAXIMUM_DISK_SIZE / 1024)} GiB)`,
     }),
 })
 

--- a/src/helpers/schemas/instance.ts
+++ b/src/helpers/schemas/instance.ts
@@ -1,6 +1,7 @@
 import { RefinementCtx, z } from 'zod'
 import { VolumeManager, VolumeType } from '@/domain/volume'
 import { messageHashSchema, paymentMethodSchema } from './base'
+import { MAXIMUM_DISK_SIZE } from '@aleph-sdk/message'
 import {
   addSpecsSchema,
   addVolumesSchema,
@@ -116,7 +117,11 @@ export const streamDurationSchema = z.object({
 })
 
 export const systemVolumeSchema = z.object({
-  size: z.number().gt(0),
+  size: z.number()
+    .gt(0, { message: 'System volume size must be greater than 0' })
+    .lte(MAXIMUM_DISK_SIZE, { 
+      message: `System volume size cannot exceed ${MAXIMUM_DISK_SIZE} MiB (${Math.round(MAXIMUM_DISK_SIZE/1024)} GiB)` 
+    }),
 })
 
 // INSTANCE

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -173,14 +173,16 @@ export const humanReadableCurrency = (value?: number, decimals = 2) => {
   if (value === Number.POSITIVE_INFINITY) return 'n/a'
   if (value === undefined) return 'n/a'
   if (value === 0) return value
-  
+
   const isNegative = value < 0
   const absValue = Math.abs(value)
   const prefix = isNegative ? '-' : ''
-  
+
   if (absValue < 1_000) return prefix + absValue.toFixed(decimals)
-  else if (absValue < 10 ** 6) return prefix + (absValue / 1_000).toFixed(decimals) + 'K'
-  else if (absValue < 10 ** 9) return prefix + (absValue / 10 ** 6).toFixed(decimals) + 'M'
+  else if (absValue < 10 ** 6)
+    return prefix + (absValue / 1_000).toFixed(decimals) + 'K'
+  else if (absValue < 10 ** 9)
+    return prefix + (absValue / 10 ** 6).toFixed(decimals) + 'M'
   else return prefix + (absValue / 10 ** 9).toFixed(decimals) + 'B'
 }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -173,10 +173,15 @@ export const humanReadableCurrency = (value?: number, decimals = 2) => {
   if (value === Number.POSITIVE_INFINITY) return 'n/a'
   if (value === undefined) return 'n/a'
   if (value === 0) return value
-  if (value < 1_000) return value.toFixed(decimals)
-  else if (value < 10 ** 6) return (value / 1_000).toFixed(decimals) + 'K'
-  else if (value < 10 ** 9) return (value / 10 ** 6).toFixed(decimals) + 'M'
-  else return (value / 10 ** 9).toFixed(decimals) + 'B'
+  
+  const isNegative = value < 0
+  const absValue = Math.abs(value)
+  const prefix = isNegative ? '-' : ''
+  
+  if (absValue < 1_000) return prefix + absValue.toFixed(decimals)
+  else if (absValue < 10 ** 6) return prefix + (absValue / 1_000).toFixed(decimals) + 'K'
+  else if (absValue < 10 ** 9) return prefix + (absValue / 10 ** 6).toFixed(decimals) + 'M'
+  else return prefix + (absValue / 10 ** 9).toFixed(decimals) + 'B'
 }
 
 const messageTypeWhitelist = new Set(Object.values(MessageType))


### PR DESCRIPTION
  ## Summary
  - Added rootfs size to ExecutableCostProps to use actual system volume size in cost
  calculations
  - Modified cost calculation to include the rootfs volume cost in execution cost
  - Added support for volume discount display in costs breakdown
  - Fixed displaying of negative costs for volume discounts
  - Added validation for system volume size against SDK maximum

  ## Test plan
  - Create an instance with a custom system volume size
  - Verify that the cost calculation correctly includes the system volume price
  - Verify that any applicable volume discounts are displayed in the cost breakdown with
  negative values
  - Verify that the total cost is calculated correctly when discounts are applied
  
  ## Examples
    
<img width="719" alt="image" src="https://github.com/user-attachments/assets/8130cea0-4737-4e23-ba9b-f51386cf7736" />
<img width="726" alt="image" src="https://github.com/user-attachments/assets/f4574f1a-54c6-460e-b5c5-78e3050f89ce" />
<img width="760" alt="image" src="https://github.com/user-attachments/assets/a46ba3de-1f76-42f3-9885-8dcc8c2b4770" />
