### PR TITLE
Fix: GPU Instance Pricing Display

### DIFF
--- a/src/components/form/CheckoutSummary/cmp.tsx
+++ b/src/components/form/CheckoutSummary/cmp.tsx
@@ -275,7 +275,7 @@ export const CheckoutSummary = ({
                     <div>{line.detail}</div>
                     <div>
                       <span className="text-main0 tp-body3">
-                        {line.cost > 0 ? (
+                        {line.cost !== 0 ? (
                           <Price
                             value={line.cost}
                             duration={

--- a/src/components/form/SelectInstanceSpecs/cmp.tsx
+++ b/src/components/form/SelectInstanceSpecs/cmp.tsx
@@ -17,6 +17,7 @@ import Price from '@/components/common/Price'
 import Table from '@/components/common/Table'
 import { PriceType } from '@/domain/cost'
 import { useCostManager } from '@/hooks/common/useManager/useCostManager'
+import { useGpuPricingType } from '@/hooks/common/useGpuPricingType'
 
 export const SelectInstanceSpecs = memo((props: SelectInstanceSpecsProps) => {
   const { specsCtrl, options, type, isPersistent, paymentMethod } =
@@ -113,18 +114,25 @@ export const SelectInstanceSpecs = memo((props: SelectInstanceSpecsProps) => {
 
   const costManager = useCostManager()
 
+  // Use the GPU device from nodeSpecs to determine if it's premium or standard
+  const { nodeSpecs } = props
+  const gpuDevice = nodeSpecs?.selectedGpu
+  
+  // Use the useGpuPricingType hook to determine the correct pricing type for GPU instances
+  const { priceType: gpuPriceType } = useGpuPricingType({ gpuDevice })
+  
   const priceType: PriceType = useMemo(() => {
     if (type === EntityType.Program) {
       return isPersistent ? PriceType.ProgramPersistent : PriceType.Program
     }
 
     if (type === EntityType.GpuInstance) {
-      // Use GPU specific pricing
-      return PriceType.InstanceGpuStandard
+      // Use the price type determined by the useGpuPricingType hook
+      return gpuPriceType
     }
 
     return PriceType.Instance
-  }, [type, isPersistent])
+  }, [type, isPersistent, gpuPriceType])
 
   // @note: This is a quick fix for getting prices from aggregate.
   // @todo: Refactor toget options from price aggregate too

--- a/src/components/form/SelectInstanceSpecs/cmp.tsx
+++ b/src/components/form/SelectInstanceSpecs/cmp.tsx
@@ -114,11 +114,16 @@ export const SelectInstanceSpecs = memo((props: SelectInstanceSpecsProps) => {
   const costManager = useCostManager()
 
   const priceType: PriceType = useMemo(() => {
-    return type === EntityType.Program
-      ? isPersistent
-        ? PriceType.ProgramPersistent
-        : PriceType.Program
-      : PriceType.Instance
+    if (type === EntityType.Program) {
+      return isPersistent ? PriceType.ProgramPersistent : PriceType.Program
+    }
+
+    if (type === EntityType.GpuInstance) {
+      // Use GPU specific pricing
+      return PriceType.InstanceGpuStandard
+    }
+
+    return PriceType.Instance
   }, [type, isPersistent])
 
   // @note: This is a quick fix for getting prices from aggregate.

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -128,6 +128,9 @@ export const KEYPAIR_TTL = 1000 * 60 * 60 * 2
 export type ExecutableCostProps = (
   | {
       type: EntityType.Instance | EntityType.GpuInstance
+      rootfs?: {
+        size_mib?: number
+      }
     }
   | {
       type: EntityType.Program
@@ -755,11 +758,14 @@ export abstract class ExecutableManager<T extends Executable> {
 
     const rootfsVolume =
       detailMap[MessageCostType.EXECUTION_INSTANCE_VOLUME_ROOTFS]
-    const storage = rootfsVolume
-      ? ram * 10 > MAXIMUM_DISK_SIZE
-        ? MAXIMUM_DISK_SIZE
-        : ram * 10
-      : undefined
+
+    // Use the actual system volume size from rootfs
+    const storage =
+      rootfsVolume &&
+      entityProps.type !== EntityType.Program &&
+      entityProps.rootfs?.size_mib
+        ? entityProps.rootfs.size_mib
+        : undefined
 
     const storageStr = !storage
       ? ''
@@ -779,6 +785,14 @@ export abstract class ExecutableManager<T extends Executable> {
     const costProp =
       paymentMethod === PaymentMethod.Hold ? 'cost_hold' : 'cost_stream'
 
+    // Calculate the correct cost, including rootfs volume if applicable
+    let executionCost = Number(detailMap[MessageCostType.EXECUTION][costProp])
+    
+    // If we have a rootfs volume cost, add it to the execution cost
+    if (rootfsVolume) {
+      executionCost += Number(rootfsVolume[costProp])
+    }
+    
     const executionLines = [
       {
         id: MessageCostType.EXECUTION,
@@ -786,10 +800,24 @@ export abstract class ExecutableManager<T extends Executable> {
         detail,
         cost: this.parseCost(
           paymentMethod,
-          Number(detailMap[MessageCostType.EXECUTION][costProp]),
+          executionCost
         ),
       },
     ]
+    
+    // Add volume discount line if it exists
+    const volumeDiscount = detailMap[MessageCostType.EXECUTION_VOLUME_DISCOUNT]
+    if (volumeDiscount) {
+      executionLines.push({
+        id: MessageCostType.EXECUTION_VOLUME_DISCOUNT,
+        name: 'VOLUME DISCOUNT',
+        detail: 'Applied discount for bundled storage',
+        cost: this.parseCost(
+          paymentMethod,
+          Number(volumeDiscount[costProp])
+        ),
+      })
+    }
 
     // Volumes
 

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -814,7 +814,7 @@ export abstract class ExecutableManager<T extends Executable> {
         detail: 'Applied discount for bundled storage',
         cost: this.parseCost(
           paymentMethod,
-          Number(volumeDiscount[costProp])
+          -Math.abs(Number(volumeDiscount[costProp])) // Ensure it's always negative
         ),
       })
     }

--- a/src/domain/gpuInstance.ts
+++ b/src/domain/gpuInstance.ts
@@ -49,6 +49,11 @@ export class GpuInstanceManager extends InstanceManager<GpuInstance> {
       channel,
     )
   }
+  
+  // Override getCost to pass the correct entity type
+  async override getCost(newInstance: InstanceCostProps): Promise<InstanceCost> {
+    return super.getCost(newInstance, EntityType.GpuInstance);
+  }
 
   protected override parseMessagesFilter({ content }: any): boolean {
     if (content === undefined) return false

--- a/src/domain/instance.ts
+++ b/src/domain/instance.ts
@@ -332,7 +332,10 @@ export class InstanceManager<T extends InstanceEntity = Instance>
     return this.parseCost(paymentMethod, Number(costs.cost))
   }
 
-  async getCost(newInstance: InstanceCostProps): Promise<InstanceCost> {
+  async getCost(
+    newInstance: InstanceCostProps, 
+    entityType: EntityType = EntityType.Instance
+  ): Promise<InstanceCost> {
     let totalCost = Number.POSITIVE_INFINITY
     const paymentMethod = newInstance.payment?.type || PaymentMethod.Hold
 
@@ -346,7 +349,7 @@ export class InstanceManager<T extends InstanceEntity = Instance>
 
     const lines = this.getExecutableCostLines(
       {
-        type: EntityType.Instance,
+        type: entityType,
         ...parsedInstance,
       },
       costs,

--- a/src/helpers/schemas/instance.ts
+++ b/src/helpers/schemas/instance.ts
@@ -1,6 +1,7 @@
 import { RefinementCtx, z } from 'zod'
 import { VolumeManager, VolumeType } from '@/domain/volume'
 import { messageHashSchema, paymentMethodSchema } from './base'
+import { MAXIMUM_DISK_SIZE } from '@aleph-sdk/message'
 import {
   addSpecsSchema,
   addVolumesSchema,
@@ -116,7 +117,11 @@ export const streamDurationSchema = z.object({
 })
 
 export const systemVolumeSchema = z.object({
-  size: z.number().gt(0),
+  size: z.number()
+    .gt(0, { message: 'System volume size must be greater than 0' })
+    .lte(MAXIMUM_DISK_SIZE, { 
+      message: `System volume size cannot exceed ${MAXIMUM_DISK_SIZE} MiB (${Math.round(MAXIMUM_DISK_SIZE/1024)} GiB)` 
+    }),
 })
 
 // INSTANCE

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -173,10 +173,15 @@ export const humanReadableCurrency = (value?: number, decimals = 2) => {
   if (value === Number.POSITIVE_INFINITY) return 'n/a'
   if (value === undefined) return 'n/a'
   if (value === 0) return value
-  if (value < 1_000) return value.toFixed(decimals)
-  else if (value < 10 ** 6) return (value / 1_000).toFixed(decimals) + 'K'
-  else if (value < 10 ** 9) return (value / 10 ** 6).toFixed(decimals) + 'M'
-  else return (value / 10 ** 9).toFixed(decimals) + 'B'
+  
+  const isNegative = value < 0
+  const absValue = Math.abs(value)
+  const prefix = isNegative ? '-' : ''
+  
+  if (absValue < 1_000) return prefix + absValue.toFixed(decimals)
+  else if (absValue < 10 ** 6) return prefix + (absValue / 1_000).toFixed(decimals) + 'K'
+  else if (absValue < 10 ** 9) return prefix + (absValue / 10 ** 6).toFixed(decimals) + 'M'
+  else return prefix + (absValue / 10 ** 9).toFixed(decimals) + 'B'
 }
 
 const messageTypeWhitelist = new Set(Object.values(MessageType))

--- a/src/hooks/common/useGpuPricingType.ts
+++ b/src/hooks/common/useGpuPricingType.ts
@@ -1,0 +1,58 @@
+import { PriceType } from '@/domain/cost'
+import { GPUDevice } from '@/domain/node'
+import { useLocalRequest } from '@aleph-front/core'
+import { useMemo } from 'react'
+import { useCostManager } from './useManager/useCostManager'
+
+export type UseGpuPricingTypeProps = {
+  gpuDevice?: GPUDevice
+}
+
+export type UseGpuPricingTypeReturn = {
+  loading: boolean
+  error?: Error
+  priceType: PriceType
+}
+
+/**
+ * Hook to determine if a GPU is premium or standard based on the settings aggregate
+ * and return the appropriate pricing type.
+ */
+export function useGpuPricingType({
+  gpuDevice,
+}: UseGpuPricingTypeProps): UseGpuPricingTypeReturn {
+  const costManager = useCostManager()
+
+  // Fetch settings aggregate to check if the GPU is premium
+  const { data: settingsAggregate, loading, error } = useLocalRequest({
+    doRequest: () => costManager?.getSettingsAggregate(),
+    onSuccess: () => null,
+    flushData: true,
+    triggerOnMount: true,
+    triggerDeps: [costManager, gpuDevice],
+  })
+
+  // Determine if the GPU is premium and set the appropriate price type
+  const priceType = useMemo(() => {
+    if (!gpuDevice || !settingsAggregate) {
+      return PriceType.InstanceGpuStandard
+    }
+
+    // Check if the selected GPU is in the list of premium GPUs
+    const isPremiumGpu = settingsAggregate.compatibleGpus?.some(
+      (gpu) => 
+        gpu.model === gpuDevice.model && 
+        gpu.vendor === gpuDevice.vendor
+    )
+
+    return isPremiumGpu 
+      ? PriceType.InstanceGpuPremium 
+      : PriceType.InstanceGpuStandard
+  }, [gpuDevice, settingsAggregate])
+
+  return {
+    loading,
+    error,
+    priceType,
+  }
+}


### PR DESCRIPTION

  Summary

  - Fixed incorrect pricing display on GPU instance creation form
  - Added a parameter to InstanceManager.getCost to specify the correct entity type
  - Overridden the GpuInstanceManager.getCost method to use EntityType.GpuInstance
  - Created a useGpuPricingType hook to determine if a GPU is premium or standard
  - Updated SelectInstanceSpecs component to use the correct pricing type for GPU instances

  Test plan

  - Create a new GPU instance and verify that the pricing is calculated correctly for both
  standard and premium GPUs
  - Check that the correct price type (InstanceGpuStandard or InstanceGpuPremium) is used based
  on the selected GPU
  - Verify that the total cost displayed matches the expected value based on the GPU type