### PR TITLE
Fix: Allow payment method switching regardless of connection state or network

### DIFF
--- a/src/hooks/pages/computing/useNewInstancePage.ts
+++ b/src/hooks/pages/computing/useNewInstancePage.ts
@@ -367,16 +367,9 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     return blockchain ? blockchains[blockchain]?.name : 'Current network'
   }, [blockchain])
 
-  const disabledStreamDisabledMessage: UseNewInstancePageReturn['disabledStreamDisabledMessage'] =
-    useMemo(() => {
-      // No longer disable payment method switching based on account compatibility
-      // We'll just display warnings and disable the submit button instead
-      return undefined
-    }, [account, blockchainName, formValues.paymentMethod])
-
-  const streamDisabled = useMemo(() => {
-    return !!disabledStreamDisabledMessage
-  }, [disabledStreamDisabledMessage])
+  // No longer disable payment method switching - allow switching regardless of connection state
+  const disabledStreamDisabledMessage = undefined
+  const streamDisabled = false
 
   const address = useMemo(() => account?.address || '', [account])
 

--- a/src/hooks/pages/computing/useNewInstancePage.ts
+++ b/src/hooks/pages/computing/useNewInstancePage.ts
@@ -369,12 +369,8 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
   const disabledStreamDisabledMessage: UseNewInstancePageReturn['disabledStreamDisabledMessage'] =
     useMemo(() => {
-      if (
-        account &&
-        !isAccountPAYGCompatible(account) &&
-        formValues.paymentMethod === PaymentMethod.Hold
-      )
-        return unsupportedStreamDisabledMessage(blockchainName)
+      // No longer disable payment method switching based on account compatibility
+      // We'll just display warnings and disable the submit button instead
       return undefined
     }, [account, blockchainName, formValues.paymentMethod])
 

--- a/src/hooks/pages/computing/useNewInstancePage.ts
+++ b/src/hooks/pages/computing/useNewInstancePage.ts
@@ -369,16 +369,13 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
   const disabledStreamDisabledMessage: UseNewInstancePageReturn['disabledStreamDisabledMessage'] =
     useMemo(() => {
-      if (!account)
-        return accountConnectionRequiredDisabledMessage(
-          'enable switching payment methods',
-        )
-
       if (
+        account &&
         !isAccountPAYGCompatible(account) &&
         formValues.paymentMethod === PaymentMethod.Hold
       )
         return unsupportedStreamDisabledMessage(blockchainName)
+      return undefined
     }, [account, blockchainName, formValues.paymentMethod])
 
   const streamDisabled = useMemo(() => {


### PR DESCRIPTION
## Summary

  - Fixes a usability issue that prevented users from switching payment methods in certain situations:
    - When not connected to a wallet
    - When connected to an incompatible network
  - Users can now freely switch between PAYG (Pay-as-you-go) and Holding tier payment methods in all circumstances
  - The submit button will still be disabled with appropriate error messages when the selected payment method is incompatible
  - This change only affects regular instances, as GPU instances are restricted to PAYG payment method only
  - Simplified the code by removing unnecessary conditional logic and useMemo hooks

## Test plan

  1. Open the "Create new instance" page without connecting a wallet
  2. Verify that the payment method toggle works and can be switched between Holding tier and PAYG
  3. Connect to an incompatible network (e.g., connect to Ethereum when trying to use PAYG)
  4. Verify that you can still switch payment methods even on incompatible networks
  5. Verify that appropriate warnings are shown and the submit button is disabled when the payment method is incompatible