### PR TITLE
Fix domain validation to support multi-level subdomains

### DIFF
--- a/src/helpers/schemas/base.ts
+++ b/src/helpers/schemas/base.ts
@@ -38,7 +38,7 @@ export const messageHashSchema = requiredStringSchema.regex(/^[0-9a-f]{64}$/, {
 // /^((?!-)[A-Za-z0-9-]{1, 63}(?<!-)\\.)+[A-Za-z]{2, 6}$/
 
 export const domainNameSchema = requiredStringSchema.regex(
-  /^((?!-))(xn--)?[a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.(xn--)?([a-z0-9\-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,})$/,
+  /^((?!-))(xn--)?([a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.)+((xn--)?([a-z0-9\-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,}))$/,
   { message: 'Invalid domain format' },
 )
 


### PR DESCRIPTION
## Summary
  - Fixed domain name validation regex to allow multiple levels of subdomains (e.g., sub1.sub2.example.com)
  - Previously the validation only allowed one level of subdomain
  - Updated regex pattern by adding the '+' quantifier to the subdomain part

 ## Test plan
  - Manually verify that domains with multiple levels like sub1.sub2.example.com can now be used
  - Ensure existing single-level subdomains continue to work