### PR TITLE
Fix: Preserve payment method when disconnecting wallet

### DIFF
--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -97,7 +97,11 @@ export function getConnectionReducer(): ConnectionReducer {
         if (action.payload && action.payload.provider !== state.provider)
           return state
 
-        return { ...initialState }
+        // Keep the current payment method but reset everything else
+        return {
+          ...initialState,
+          paymentMethod: state.paymentMethod,
+        }
       }
 
       case ConnectionActionType.CONNECTION_CONNECT:


### PR DESCRIPTION
## Summary

  - Fixes an issue where the payment method selection was reset when disconnecting a wallet
  - Now preserves the user's payment method choice after wallet disconnection

## Test plan

  - Connect wallet and select PAYG payment method
  - Disconnect wallet
  - Verify payment method remains set to PAYG instead of resetting to HOLD