### PR TITLE
fix: ensure correct network for deleting PAYG instances

### DIFF
--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -69,4 +69,8 @@ export default {
     new Error(`Unsupported GPU model: ${gpuModel}`),
   UnsupportedPaymentMethod: (paymentMethod?: string) =>
     new Error(`Unsupported payment method. ${paymentMethod}`),
+  NetworkMismatch: (requiredNetwork: string) =>
+    new Error(
+      `This instance was created on the ${requiredNetwork} network. Please switch to ${requiredNetwork} to manage it.`,
+    ),
 }


### PR DESCRIPTION
 ## Summary
  - Fixes bug where PAYG instances could be incorrectly deleted when user is on the wrong network (eg. Ethereum instead of Base/Avax)
  - Now shows a clear error message requiring the user to manually switch to the correct network before deletion
  - Prevents deletion of payment streams without proper network context
  - Refactors network checking into a reusable function

  ## Test plan
  1. Create a PAYG instance on Base or Avalanche
  2. Switch to Ethereum network
  3. Try to delete the instance
  4. Verify that proper error message is shown (should indicate which network to use)
  5. Switch to the correct network and verify deletion works properly