### PR TITLE
fix: scroll to top when navigating

### DIFF
--- a/src/components/common/Content/cmp.tsx
+++ b/src/components/common/Content/cmp.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, ForwardedRef, memo, useRef } from 'react'
+import { StyledContent } from './styles'
+import { ContentProps } from './types'
+import useResetScroll from '@/hooks/common/useResetScroll'
+
+export const Content = forwardRef(
+  ({ children, ...props }: ContentProps, ref: ForwardedRef<HTMLDivElement>) => {
+    // Create a local ref if none is provided through forwardRef
+    const localRef = useRef<HTMLDivElement>(null)
+    const contentRef = (ref || localRef) as React.RefObject<HTMLDivElement>
+
+    // Use the custom hook to handle scroll reset
+    useResetScroll([contentRef])
+
+    return (
+      <StyledContent ref={ref || localRef} {...props}>
+        {children}
+      </StyledContent>
+    )
+  },
+)
+
+Content.displayName = 'Content'
+
+export default memo(Content) as typeof Content

--- a/src/components/common/Content/index.ts
+++ b/src/components/common/Content/index.ts
@@ -1,2 +1,2 @@
-export { default } from './styles'
+export { default } from './cmp'
 export type { ContentProps } from './types'

--- a/src/components/common/Content/styles.tsx
+++ b/src/components/common/Content/styles.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import tw from 'twin.macro'
 
 export const StyledContent = styled.div`
-  ${tw`relative flex-1`}
+  ${tw`relative flex-1 scroll-smooth`}
 `
 
 export default StyledContent

--- a/src/hooks/common/useResetScroll.ts
+++ b/src/hooks/common/useResetScroll.ts
@@ -1,0 +1,56 @@
+import { useRouter } from 'next/router'
+import { useEffect, RefObject } from 'react'
+
+/**
+ * Hook to reset scroll positions when navigating between pages
+ * @param refs An array of refs to scrollable HTML elements
+ * @param behavior The scroll behavior (default is 'smooth')
+ */
+export default function useResetScroll(
+  refs: RefObject<HTMLElement>[] = [],
+  behavior: ScrollBehavior = 'smooth',
+) {
+  const router = useRouter()
+
+  useEffect(() => {
+    const resetScroll = () => {
+      // Scroll configuration
+      const scrollOptions = {
+        top: 0,
+        left: 0,
+        behavior: behavior,
+      }
+
+      // Reset window scroll
+      window.scrollTo(scrollOptions)
+
+      // Reset document elements
+      if (document.documentElement)
+        document.documentElement.scrollTop = scrollOptions.top
+
+      // Reset body scroll
+      if (document.body) document.body.scrollTop = scrollOptions.top
+
+      // Reset all provided refs
+      refs.forEach((ref) => {
+        if (ref?.current) {
+          if (typeof ref.current.scrollTo === 'function') {
+            ref.current.scrollTo(scrollOptions)
+          } else {
+            ref.current.scrollTop = scrollOptions.top
+          }
+        }
+      })
+    }
+
+    // Reset scroll on initial load
+    resetScroll()
+
+    // Listen for route changes
+    router.events.on('routeChangeComplete', resetScroll)
+
+    return () => {
+      router.events.off('routeChangeComplete', resetScroll)
+    }
+  }, [router, refs, behavior])
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,7 +14,7 @@ import Content from '@/components/common/Content'
 import Viewport from '@/components/common/Viewport'
 import Sidebar from '@/components/common/Sidebar'
 import { AppStateProvider } from '@/contexts/appState'
-//import { HeliaProvider } from '@/contexts/helia'
+import useResetScroll from '@/hooks/common/useResetScroll'
 import Loading from './_loading'
 import { useRef } from 'react'
 import Head from 'next/head'
@@ -22,6 +22,8 @@ import Head from 'next/head'
 export default function App({ Component, pageProps }: AppProps) {
   const mainRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
+
+  useResetScroll([mainRef, contentRef])
 
   return (
     <ThemeProvider theme={themes.twentysix}>

--- a/src/styles/global.tsx
+++ b/src/styles/global.tsx
@@ -1,7 +1,7 @@
 import { createGlobalStyle } from 'styled-components'
 
 export const GlobalStylesOverride = createGlobalStyle`
- html, body, #__next {
+  html, body, #__next {
     height: 100%;
   }
 


### PR DESCRIPTION
## Summary
  - Implemented automatic scroll reset when navigating between pages for a smoother user experience
  - Created a reusable useResetScroll hook for consistent scroll behavior across the application
  - Added smooth scrolling animation to make page transitions feel more polished

## Technical details
This PR addresses the issue where scroll position was retained when navigating between pages, causing users to start new pages at the same scroll position they left the previous page.

 ### Changes include:
  - Created a custom useResetScroll hook that handles scroll position reset for both window and specific container elements
  - Implemented the hook in the main App component and Content component
  - Used the ScrollBehavior API to enable smooth scrolling transitions

## Testing
  - Verified scroll reset works when navigating between pages with different scroll positions
  - Confirmed smooth scrolling provides a pleasant user experience