### PR TITLE
Refactor: filter out inactive nodes

### DIFF
--- a/src/components/pages/account/ComputeResourceNodesPage/cmp.tsx
+++ b/src/components/pages/account/ComputeResourceNodesPage/cmp.tsx
@@ -42,6 +42,8 @@ export const ComputeResourceNodesPage = (
     isLinkableOnlyDisabled,
     totalResources,
     loadItemsDisabled,
+    showInactive,
+    handleShowInactiveChange,
     handleLoadItems,
     handleSortItems,
     handleLink,
@@ -142,6 +144,12 @@ export const ComputeResourceNodesPage = (
                   onChange={handleLinkableOnlyChange}
                   size="xs"
                   disabled={isLinkableOnlyDisabled}
+                />
+                <Checkbox
+                  label="Show inactive nodes"
+                  checked={showInactive}
+                  onChange={handleShowInactiveChange}
+                  size="xs"
                 />
               </div>
               <TextInput

--- a/src/components/pages/account/ComputeResourceNodesPage/hook.tsx
+++ b/src/components/pages/account/ComputeResourceNodesPage/hook.tsx
@@ -22,7 +22,10 @@ export type UseComputeResourceNodesPageProps = {
   nodes?: CRN[]
 }
 
-export type UseComputeResourceNodesPageReturn = UseComputeResourceNodesReturn &
+export type UseComputeResourceNodesPageReturn = Omit<
+  UseComputeResourceNodesReturn,
+  'filteredNodes'
+> &
   Pick<UseLinkingReturn, 'handleLink' | 'handleUnlink'> & {
     userNodes?: CRN[]
     filteredUserNodes?: CRN[]
@@ -54,6 +57,8 @@ export function useComputeResourceNodesPage(
   const {
     nodes,
     filteredNodes: baseFilteredNodes,
+    showInactive,
+    handleShowInactiveChange,
     ...rest
   } = useComputeResourceNodes(props)
   const { account } = rest
@@ -215,7 +220,6 @@ export function useComputeResourceNodesPage(
 
   return {
     nodes,
-    filteredNodes,
     userNodes,
     filteredUserNodes,
     userNodesIssues,
@@ -232,6 +236,8 @@ export function useComputeResourceNodesPage(
     handleUnlink,
     handleTabChange,
     handleLinkableOnlyChange,
+    showInactive,
+    handleShowInactiveChange,
     ...rest,
   }
 }

--- a/src/components/pages/account/CoreChannelNodesPage/cmp.tsx
+++ b/src/components/pages/account/CoreChannelNodesPage/cmp.tsx
@@ -1,6 +1,13 @@
 import { memo } from 'react'
 import Head from 'next/head'
-import { Button, Icon, Tabs, TextGradient, TextInput } from '@aleph-front/core'
+import {
+  Button,
+  Checkbox,
+  Icon,
+  Tabs,
+  TextGradient,
+  TextInput,
+} from '@aleph-front/core'
 import { UseCoreChannelNodesPageProps, useCoreChannelNodesPage } from './hook'
 import CoreChannelNodesTable from '@/components/common/CoreChannelNodesTable'
 import ExternalLinkButton from '@/components/common/ExternalLinkButton'
@@ -28,10 +35,12 @@ export const CoreChannelNodesPage = (props: UseCoreChannelNodesPageProps) => {
     filter,
     lastVersion,
     loadItemsDisabled,
+    showInactive,
     handleLoadItems,
     handleSortItems,
     handleTabChange,
     handleFilterChange,
+    handleShowInactiveChange,
   } = useCoreChannelNodesPage(props)
 
   const { render } = useLazyRender()
@@ -119,6 +128,12 @@ export const CoreChannelNodesPage = (props: UseCoreChannelNodesPageProps) => {
                   align="left"
                   selected={selectedTab}
                   onTabChange={handleTabChange}
+                />
+                <Checkbox
+                  label="Show inactive nodes"
+                  checked={showInactive}
+                  onChange={handleShowInactiveChange}
+                  size="xs"
                 />
               </div>
               <TextInput

--- a/src/components/pages/account/CoreChannelNodesPage/hook.tsx
+++ b/src/components/pages/account/CoreChannelNodesPage/hook.tsx
@@ -36,7 +36,13 @@ export function useCoreChannelNodesPage(
   const [state] = useAppState()
   const { account, balance: accountBalance = 0 } = state.connection
 
-  const { nodes, filteredNodes, ...rest } = useCoreChannelNodes(props)
+  const {
+    nodes,
+    filteredNodes,
+    showInactive,
+    handleShowInactiveChange,
+    ...rest
+  } = useCoreChannelNodes(props)
 
   // -----------------------------
 
@@ -111,5 +117,7 @@ export function useCoreChannelNodesPage(
     loadItemsDisabled,
     handleLoadItems,
     handleTabChange,
+    showInactive,
+    handleShowInactiveChange,
   }
 }

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -58,6 +58,7 @@ export type BaseNode = {
   picture?: string
   banner?: string
   description?: string
+  inactive_since?: number
   manager?: string // not needed in CRN & optional in CCN
 
   // --------- CCN fields ?

--- a/src/hooks/common/node/useComputeResourceNodes.ts
+++ b/src/hooks/common/node/useComputeResourceNodes.ts
@@ -24,8 +24,10 @@ export type UseComputeResourceNodesReturn = {
   filteredNodes?: CRN[]
   filter?: string
   lastVersion?: NodeLastVersions
+  showInactive: boolean
   handleSortItems: UseSortedListReturn<CRN>['handleSortItems']
   handleFilterChange: (e: ChangeEvent<HTMLInputElement>) => void
+  handleShowInactiveChange: (e: ChangeEvent<HTMLInputElement>) => void
 } & Pick<UseFiltersReturn, 'filters'>
 
 export function useComputeResourceNodes({
@@ -54,6 +56,7 @@ export function useComputeResourceNodes({
   })
 
   const [filter, setFilter] = useState<string>()
+  const [showInactive, setShowInactive] = useState<boolean>(false)
 
   const handleFilterChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -62,6 +65,13 @@ export function useComputeResourceNodes({
       setCrnqFilter(filter)
     },
     [setCrnqFilter],
+  )
+
+  const handleShowInactiveChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setShowInactive(e.target.checked)
+    },
+    [],
   )
 
   useEffect(() => {
@@ -82,8 +92,12 @@ export function useComputeResourceNodes({
   }, [])
 
   const filterInactiveNodes = useCallback(
-    () => (node: CRN) => !node.inactive_since && node.score > 0,
-    [],
+    () => (node: CRN) => {
+      if (showInactive) return true
+
+      return !node.inactive_since && node.score > 0
+    },
+    [showInactive],
   )
 
   const nodes = useMemo(() => {
@@ -116,7 +130,9 @@ export function useComputeResourceNodes({
     filter,
     lastVersion,
     filters,
+    showInactive,
     handleSortItems,
     handleFilterChange,
+    handleShowInactiveChange,
   }
 }


### PR DESCRIPTION
## Description

By default, inactive CRNs and CCNs are filtered out. A checkbox has been added to allow the user decide whether to see inactive nodes or not.