### PR TITLE
fix: use same wording for button labels to create instances

### DIFF
--- a/src/components/pages/console/confidential/ConfidentialDashboardPage/cmp.tsx
+++ b/src/components/pages/console/confidential/ConfidentialDashboardPage/cmp.tsx
@@ -34,7 +34,7 @@ export default function ConfidentialDashboardPage() {
               title="Confidential Instance"
               description="Protect your sensitive workloads with our Confidential VMs. Designed for maximum privacy and security, ensuring your execution and data stays safe."
               buttonUrl="/console/computing/confidential/new"
-              buttonText="Create Confidential"
+              buttonText="Create a Confidential Instance"
               externalLinkText="Developer docs"
               externalLinkUrl={NAVIGATION_URLS.docs.confidentials}
             />


### PR DESCRIPTION
The button for GPU instances has a "Create a GPU Instance" label while the button for confidential VMs reads "Create Confidential". Harmonized the two.