### PR TITLE
feat: add WEB ACCESS section showing 2n6.me proxy URL on instance pages

### DIFF
--- a/src/components/common/entityData/EntityProxyUrl/cmp.tsx
+++ b/src/components/common/entityData/EntityProxyUrl/cmp.tsx
@@ -1,0 +1,57 @@
+import React, { memo } from 'react'
+import { NoisyContainer } from '@aleph-front/core'
+import { EntityProxyUrlProps } from './types'
+import Skeleton from '../../Skeleton'
+import { Text } from '@/components/pages/console/common'
+import IconText from '../../IconText'
+import InfoTitle from '../InfoTitle'
+import { useEntityProxyUrl } from './hook'
+
+export const EntityProxyUrl = ({ instanceHash }: EntityProxyUrlProps) => {
+  const { data, loading } = useEntityProxyUrl(instanceHash)
+
+  return (
+    <>
+      <div className="tp-h7 fs-24" tw="uppercase mb-2">
+        WEB ACCESS
+      </div>
+      <NoisyContainer>
+        <div tw="flex flex-col gap-4">
+          <div>
+            <InfoTitle>PROXY URL</InfoTitle>
+            <div>
+              {loading ? (
+                <Skeleton width="16rem" />
+              ) : data ? (
+                <a
+                  className="tp-body1 fs-16"
+                  href={`https://${data.url}`}
+                  target="_blank"
+                  referrerPolicy="no-referrer"
+                >
+                  <IconText iconName="square-up-right">
+                    <Text>{data.url}</Text>
+                  </IconText>
+                </a>
+              ) : (
+                <Text>Unavailable</Text>
+              )}
+            </div>
+          </div>
+          <div>
+            <InfoTitle>INFO</InfoTitle>
+            <Text className="fs-12" tw="opacity-60">
+              If your instance runs a web server, it&apos;s already accessible
+              at this URL. HTTPS traffic is forwarded transparently (L4), so
+              you&apos;ll need to handle TLS certificates on your instance.
+              HTTP traffic (port 80) is also forwarded.
+            </Text>
+          </div>
+        </div>
+      </NoisyContainer>
+    </>
+  )
+}
+EntityProxyUrl.displayName = 'EntityProxyUrl'
+
+export default memo(EntityProxyUrl) as typeof EntityProxyUrl

--- a/src/components/common/entityData/EntityProxyUrl/hook.ts
+++ b/src/components/common/entityData/EntityProxyUrl/hook.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+import { ProxyUrlData } from './types'
+
+const PROXY_API_BASE = 'https://api.2n6.me'
+
+export function useEntityProxyUrl(instanceHash?: string) {
+  const [data, setData] = useState<ProxyUrlData | undefined>()
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!instanceHash) {
+      setData(undefined)
+      return
+    }
+
+    const fetchProxyUrl = async () => {
+      setLoading(true)
+      try {
+        const res = await fetch(
+          `${PROXY_API_BASE}/api/hash/${instanceHash}`,
+        )
+        if (!res.ok) {
+          setData(undefined)
+          return
+        }
+        const json = await res.json()
+        setData(json)
+      } catch (e) {
+        console.error('Failed to fetch proxy URL:', e)
+        setData(undefined)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchProxyUrl()
+  }, [instanceHash])
+
+  return { data, loading }
+}

--- a/src/components/common/entityData/EntityProxyUrl/index.tsx
+++ b/src/components/common/entityData/EntityProxyUrl/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/common/entityData/EntityProxyUrl/types.ts
+++ b/src/components/common/entityData/EntityProxyUrl/types.ts
@@ -1,0 +1,11 @@
+export type ProxyUrlData = {
+  instance_hash: string
+  subdomain: string
+  url: string
+  ipv6: string | null
+  active: boolean
+}
+
+export type EntityProxyUrlProps = {
+  instanceHash?: string
+}

--- a/src/components/pages/console/confidential/ManageConfidential/cmp.tsx
+++ b/src/components/pages/console/confidential/ManageConfidential/cmp.tsx
@@ -15,6 +15,7 @@ import EntityLinkedVolumes from '@/components/common/entityData/EntityLinkedVolu
 import EntityPersistentStorage from '@/components/common/entityData/EntityPersistentStorage'
 import EntityCustomDomains from '@/components/common/entityData/EntityCustomDomains'
 import EntityPortForwarding from '@/components/common/entityData/EntityPortForwarding'
+import EntityProxyUrl from '@/components/common/entityData/EntityProxyUrl'
 import { EntityDomainType } from '@/helpers/constants'
 import SidePanel from '@/components/common/SidePanel'
 import VolumeDetail from '@/components/common/VolumeDetail'
@@ -163,6 +164,10 @@ export default function ManageConfidential() {
             key="confidentialInstance-connection-methods"
             executableStatus={status}
             sshForwardedPort={sshForwardedPort}
+          />,
+          <EntityProxyUrl
+            key="confidentialInstance-proxy-url"
+            instanceHash={confidentialInstance?.id}
           />,
           immutableVolumes.length && (
             <EntityLinkedVolumes

--- a/src/components/pages/console/gpuInstance/ManageGpuInstance/cmp.tsx
+++ b/src/components/pages/console/gpuInstance/ManageGpuInstance/cmp.tsx
@@ -15,6 +15,7 @@ import EntityLinkedVolumes from '@/components/common/entityData/EntityLinkedVolu
 import EntityPersistentStorage from '@/components/common/entityData/EntityPersistentStorage'
 import EntityCustomDomains from '@/components/common/entityData/EntityCustomDomains'
 import EntityPortForwarding from '@/components/common/entityData/EntityPortForwarding'
+import EntityProxyUrl from '@/components/common/entityData/EntityProxyUrl'
 import { EntityDomainType } from '@/helpers/constants'
 import SidePanel from '@/components/common/SidePanel'
 import VolumeDetail from '@/components/common/VolumeDetail'
@@ -160,6 +161,10 @@ export default function ManageGpuInstance() {
             key="gpuInstance-connection-methods"
             executableStatus={status}
             sshForwardedPort={sshForwardedPort}
+          />,
+          <EntityProxyUrl
+            key="gpuInstance-proxy-url"
+            instanceHash={gpuInstance?.id}
           />,
           immutableVolumes.length && (
             <EntityLinkedVolumes

--- a/src/components/pages/console/instance/ManageInstance/cmp.tsx
+++ b/src/components/pages/console/instance/ManageInstance/cmp.tsx
@@ -20,6 +20,7 @@ import EntityDataColumns from '@/components/common/entityData/EntityDataColumns'
 import EntityCustomDomains from '@/components/common/entityData/EntityCustomDomains'
 import DomainDetail from '@/components/common/DomainDetail'
 import EntityPortForwarding from '@/components/common/entityData/EntityPortForwarding'
+import EntityProxyUrl from '@/components/common/entityData/EntityProxyUrl'
 import NewDomainForm from '@/components/common/NewDomainForm'
 
 /**
@@ -160,6 +161,10 @@ export default function ManageInstance() {
             key="instance-connection-methods"
             executableStatus={status}
             sshForwardedPort={sshForwardedPort}
+          />,
+          <EntityProxyUrl
+            key="instance-proxy-url"
+            instanceHash={instance?.id}
           />,
           immutableVolumes.length && (
             <EntityLinkedVolumes


### PR DESCRIPTION
## Summary                                                                                                  
  - Adds a new WEB ACCESS section to instance, GPU instance, and TEE instance detail pages
  - Displays the auto-assigned 2n6.me proxy URL by fetching from the domain gateway API
  - Every instance automatically gets a free proxy that forwards ports 80 and 443 (L4 transparent) on a
  subdomain of 2n6.me

  ## Test plan
  - [ ] Navigate to an instance detail page and verify the WEB ACCESS section appears between Connection
  Methods and Custom Domains
  - [ ] Verify the proxy URL is displayed as a clickable link
  - [ ] Check GPU instance and TEE instance pages also show the section