### PR TITLE
Feat: Autoselect crn

### DIFF
--- a/src/components/common/CRNList/cmp.tsx
+++ b/src/components/common/CRNList/cmp.tsx
@@ -20,6 +20,7 @@ import SpinnerOverlay from '@/components/common/SpinnerOverlay'
 import { RotatingLines } from 'react-loader-spinner'
 import { useTheme } from 'styled-components'
 import { CRNItem, CRNListProps } from './types'
+import BorderBox from '@/components/common/BorderBox'
 
 export default function CRNList(props: CRNListProps) {
   const {
@@ -29,6 +30,7 @@ export default function CRNList(props: CRNListProps) {
     specs,
     nodesIssues,
     filteredNodes,
+    totalCompatibleNodes,
     filterOptions,
     loading,
     loadItemsDisabled,
@@ -325,6 +327,18 @@ export default function CRNList(props: CRNListProps) {
         tw="min-h-[20rem] h-full overflow-auto"
         ref={infiniteScrollContainerRef}
       >
+        {!loading && totalCompatibleNodes === 0 && (
+          <BorderBox $color="warning" tw="mb-6">
+            <div tw="flex items-start gap-3">
+              <Icon name="warning" tw="flex-shrink-0 mt-0.5" />
+              <p className="tp-body1">
+                {enableGpu
+                  ? 'No GPU nodes are currently available in the network. Please try again later or contact support if this issue persists.'
+                  : 'No compatible nodes are currently available in the network. Please try again later or adjust your tier selection.'}
+              </p>
+            </div>
+          </BorderBox>
+        )}
         <NodesTable
           {...{
             columns,

--- a/src/components/common/CRNList/types.ts
+++ b/src/components/common/CRNList/types.ts
@@ -1,4 +1,8 @@
-import { CRNSpecs, StreamNotSupportedIssue } from '@/domain/node'
+import {
+  CRNSpecs,
+  ReducedCRNSpecs,
+  StreamNotSupportedIssue,
+} from '@/domain/node'
 
 export type CRNItem = CRNSpecs & {
   isActive: boolean
@@ -11,4 +15,5 @@ export type CRNListProps = {
   enableGpu?: boolean
   selected?: CRNSpecs
   onSelectedChange: (selected: CRNSpecs) => void
+  filterBySpecs?: ReducedCRNSpecs
 }

--- a/src/components/form/SelectInstanceSpecs/types.ts
+++ b/src/components/form/SelectInstanceSpecs/types.ts
@@ -3,6 +3,7 @@ import { EntityType } from '@/helpers/constants'
 import { InstanceSpecsField } from '@/hooks/form/useSelectInstanceSpecs'
 import { CRNSpecs } from '@/domain/node'
 import { ReactNode } from 'react'
+import { AggregatedNodeSpecs } from '@/hooks/common/useAggregatedNodeSpecs'
 
 export type SelectInstanceSpecsProps = {
   name?: string
@@ -12,6 +13,7 @@ export type SelectInstanceSpecsProps = {
   gpuModel?: string
   isPersistent?: boolean
   nodeSpecs?: CRNSpecs
+  aggregatedSpecs?: AggregatedNodeSpecs
   children?: ReactNode
   showOpenClawSpotlight?: boolean
 }

--- a/src/components/pages/console/gpuInstance/NewGpuInstancePage/cmp.tsx
+++ b/src/components/pages/console/gpuInstance/NewGpuInstancePage/cmp.tsx
@@ -35,6 +35,7 @@ import { PageProps } from '@/types/types'
 import Strong from '@/components/common/Strong'
 import CRNList from '../../../../common/CRNList'
 import BackButtonSection from '@/components/common/BackButtonSection'
+import BorderBox from '@/components/common/BorderBox'
 import ExternalLink from '@/components/common/ExternalLink'
 import { useNewGpuInstancePage } from './hook'
 import CheckoutButton from '@/components/form/CheckoutButton'
@@ -148,21 +149,29 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
             </p>
             <div tw="px-0 mt-12 mb-6 min-h-[6rem] relative">
               <NoisyContainer>
-                {node ? (
-                  <>
-                    <NodesTable
-                      columns={columns}
-                      data={nodeData}
-                      rowProps={() => ({ className: '_active' })}
-                    />
-                    <div tw="mt-4 flex items-center gap-2 opacity-60">
-                      <Icon name="info-circle" size="sm" />
-                      <span className="tp-body3">
-                        Auto-selected best CRN with this GPU (
-                        {compatibleNodesCount} compatible nodes)
-                      </span>
+                {node?.selectedGpu ? (
+                  <div tw="flex items-center justify-between p-2">
+                    <div tw="flex items-center gap-4">
+                      <Icon name="cube" size="lg" tw="opacity-60" />
+                      <div>
+                        <p className="tp-body2" tw="opacity-60 mb-1">
+                          Selected GPU
+                        </p>
+                        <p className="tp-body1 font-bold">
+                          {node.selectedGpu.model}
+                        </p>
+                      </div>
                     </div>
-                  </>
+                    <Button
+                      type="button"
+                      kind="functional"
+                      size="md"
+                      variant="warning"
+                      onClick={handleManuallySelectCRN}
+                    >
+                      Change GPU
+                    </Button>
+                  </div>
                 ) : (
                   <div tw="p-6 text-center">
                     <p tw="mb-4 opacity-60">No GPU selected yet</p>
@@ -369,21 +378,18 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         header=""
         content={
           <>
-            {node?.selectedGpu?.model && (
-              <NoisyContainer tw="mb-6 p-4">
+            {node?.selectedGpu?.model && values.specs && (
+              <BorderBox $color="warning" tw="mb-6">
                 <div tw="flex items-start gap-3">
-                  <Icon
-                    name="warning"
-                    tw="text-orange-500 flex-shrink-0 mt-0.5"
-                  />
-                  <p className="tp-body2">
+                  <Icon name="warning" tw="flex-shrink-0 mt-0.5" />
+                  <p className="tp-body1">
                     The node list below is filtered to show only{' '}
                     <Strong>{compatibleNodesCount}</Strong> nodes with{' '}
                     <Strong>{node.selectedGpu.model}</Strong> GPU compatible
                     with your selected tier.
                   </p>
                 </div>
-              </NoisyContainer>
+              </BorderBox>
             )}
             <CRNList
               enableGpu

--- a/src/components/pages/console/gpuInstance/NewGpuInstancePage/cmp.tsx
+++ b/src/components/pages/console/gpuInstance/NewGpuInstancePage/cmp.tsx
@@ -11,6 +11,7 @@ import {
   NoisyContainer,
   Checkbox,
   Modal,
+  Icon,
 } from '@aleph-front/core'
 import ButtonWithInfoTooltip from '@/components/common/ButtonWithInfoTooltip'
 import { CRNSpecs } from '@/domain/node'
@@ -60,6 +61,8 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
     setSelectedNode,
     termsAndConditions,
     shouldRequestTermsAndConditions,
+    aggregatedSpecs,
+    compatibleNodesCount,
     handleManuallySelectCRN,
     handleSelectNode,
     handleSubmit,
@@ -135,55 +138,60 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={1}>
-              Selected GPU
-            </CompositeSectionTitle>
+            <CompositeSectionTitle number={1}>Select GPU</CompositeSectionTitle>
             <p>
-              Your instance is configured with your manually selected GPU,
-              operating under the <Strong>credit-based</Strong> payment system.
-              This setup provides direct control over your resource allocation
-              and costs. Your credits are deducted only as you consume
-              resources, ensuring you pay exactly for what you use. To adjust
-              your GPU, modify your selection below.
+              Select a GPU for your instance. This will determine the available
+              tiers and configuration options. Operating under the{' '}
+              <Strong>credit-based</Strong> payment system, your credits are
+              deducted only as you consume resources, ensuring you pay exactly
+              for what you use.
             </p>
             <div tw="px-0 mt-12 mb-6 min-h-[6rem] relative">
               <NoisyContainer>
-                <NodesTable
-                  columns={columns}
-                  data={nodeData}
-                  rowProps={() => ({ className: '_active' })}
-                />
-                <div tw="mt-6">
-                  {!node && (
-                    <>
-                      <ButtonWithInfoTooltip
-                        ref={manuallySelectButtonRef}
-                        type="button"
-                        kind="functional"
-                        variant="warning"
-                        size="md"
-                        disabled={manuallySelectCRNDisabled}
-                        tooltipContent={manuallySelectCRNDisabledMessage}
-                        onClick={handleManuallySelectCRN}
-                      >
-                        Manually select GPU
-                      </ButtonWithInfoTooltip>
-                    </>
-                  )}
-                </div>
+                {node ? (
+                  <>
+                    <NodesTable
+                      columns={columns}
+                      data={nodeData}
+                      rowProps={() => ({ className: '_active' })}
+                    />
+                    <div tw="mt-4 flex items-center gap-2 opacity-60">
+                      <Icon name="info-circle" size="sm" />
+                      <span className="tp-body3">
+                        Auto-selected best CRN with this GPU (
+                        {compatibleNodesCount} compatible nodes)
+                      </span>
+                    </div>
+                  </>
+                ) : (
+                  <div tw="p-6 text-center">
+                    <p tw="mb-4 opacity-60">No GPU selected yet</p>
+                    <ButtonWithInfoTooltip
+                      ref={manuallySelectButtonRef}
+                      type="button"
+                      kind="functional"
+                      variant="warning"
+                      size="md"
+                      disabled={manuallySelectCRNDisabled}
+                      tooltipContent={manuallySelectCRNDisabledMessage}
+                      onClick={handleManuallySelectCRN}
+                    >
+                      Select GPU
+                    </ButtonWithInfoTooltip>
+                  </div>
+                )}
               </NoisyContainer>
             </div>
           </CenteredContainer>
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={1}>
+            <CompositeSectionTitle number={2}>
               Select your tier
             </CompositeSectionTitle>
             <p>
               Please select one of the available instance tiers as a base for
-              your VM. You will be able to customize the volumes further below
-              in the form.
+              your VM. Tiers are filtered based on your selected GPU.
             </p>
 
             <div tw="px-0 my-6 relative">
@@ -195,10 +203,11 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
                 gpuModel={node?.selectedGpu?.model}
                 isPersistent
                 nodeSpecs={nodeSpecs}
+                aggregatedSpecs={aggregatedSpecs}
               >
                 {!node && (
                   <div tw="mt-6 text-center">
-                    First select your node in the previous step
+                    First select your GPU in the previous step
                   </div>
                 )}
               </SelectInstanceSpecs>
@@ -207,7 +216,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={2}>
+            <CompositeSectionTitle number={3}>
               Choose an image
             </CompositeSectionTitle>
             <p>
@@ -221,7 +230,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={3}>
+            <CompositeSectionTitle number={4}>
               Configure SSH Key
             </CompositeSectionTitle>
             <p>
@@ -237,7 +246,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={4}>
+            <CompositeSectionTitle number={5}>
               Name and tags
             </CompositeSectionTitle>
             <p tw="mb-6">
@@ -254,13 +263,13 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={5}>
+            <CompositeSectionTitle number={6}>
               Advanced Configuration Options
             </CompositeSectionTitle>
             <p tw="mb-6">
               Customize your GPU Instance with our Advanced Configuration
-              Options. Add volumes and custom domains to meet your specific
-              needs.
+              Options. Add volumes, custom domains, or select a specific CRN
+              node.
             </p>
             <div tw="px-0 my-6">
               <div tw="mb-4">
@@ -292,6 +301,27 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
                     control={control}
                     entityType={EntityDomainType.Instance}
                   />
+                </SwitchToggleContainer>
+              </div>
+              <div tw="mb-4">
+                <SwitchToggleContainer label="Custom Node Selection">
+                  <TextGradient forwardedAs="h2" type="h6" color="main0">
+                    CRN Node Selection
+                  </TextGradient>
+                  <p tw="mb-6">
+                    By default, the best performing CRN node with your selected
+                    GPU is automatically chosen. You can manually select a
+                    different node with the same GPU below if needed.
+                  </p>
+                  {node && (
+                    <NoisyContainer>
+                      <NodesTable
+                        columns={columns}
+                        data={nodeData}
+                        rowProps={() => ({ className: '_active' })}
+                      />
+                    </NoisyContainer>
+                  )}
                 </SwitchToggleContainer>
               </div>
             </div>
@@ -338,11 +368,30 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         width="80rem"
         header=""
         content={
-          <CRNList
-            enableGpu
-            selected={selectedNode}
-            onSelectedChange={setSelectedNode}
-          />
+          <>
+            {node?.selectedGpu?.model && (
+              <NoisyContainer tw="mb-6 p-4">
+                <div tw="flex items-start gap-3">
+                  <Icon
+                    name="warning"
+                    tw="text-orange-500 flex-shrink-0 mt-0.5"
+                  />
+                  <p className="tp-body2">
+                    The node list below is filtered to show only{' '}
+                    <Strong>{compatibleNodesCount}</Strong> nodes with{' '}
+                    <Strong>{node.selectedGpu.model}</Strong> GPU compatible
+                    with your selected tier.
+                  </p>
+                </div>
+              </NoisyContainer>
+            )}
+            <CRNList
+              enableGpu
+              selected={selectedNode}
+              onSelectedChange={setSelectedNode}
+              filterBySpecs={values.specs}
+            />
+          </>
         }
         footer={
           <div tw="w-full flex justify-end">
@@ -373,7 +422,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
             <div tw="flex items-center gap-4 max-w-md mb-8">
               <Checkbox
                 onChange={handleCheckTermsAndConditions}
-                checked={values.termsAndConditions}
+                checked={!!values.termsAndConditions}
               />
               <div className="tp-body">
                 I have read, understood, and agree to the{' '}

--- a/src/components/pages/console/gpuInstance/NewGpuInstancePage/cmp.tsx
+++ b/src/components/pages/console/gpuInstance/NewGpuInstancePage/cmp.tsx
@@ -11,6 +11,7 @@ import {
   NoisyContainer,
   Checkbox,
   Modal,
+  Icon,
 } from '@aleph-front/core'
 import ButtonWithInfoTooltip from '@/components/common/ButtonWithInfoTooltip'
 import { CRNSpecs } from '@/domain/node'
@@ -60,6 +61,8 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
     setSelectedNode,
     termsAndConditions,
     shouldRequestTermsAndConditions,
+    aggregatedSpecs,
+    compatibleNodesCount,
     handleManuallySelectCRN,
     handleSelectNode,
     handleSubmit,
@@ -135,55 +138,60 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={1}>
-              Selected GPU
-            </CompositeSectionTitle>
+            <CompositeSectionTitle number={1}>Select GPU</CompositeSectionTitle>
             <p>
-              Your instance is configured with your manually selected GPU,
-              operating under the <Strong>credit-based</Strong> payment system.
-              This setup provides direct control over your resource allocation
-              and costs. Your credits are deducted only as you consume
-              resources, ensuring you pay exactly for what you use. To adjust
-              your GPU, modify your selection below.
+              Select a GPU for your instance. This will determine the available
+              tiers and configuration options. Operating under the{' '}
+              <Strong>credit-based</Strong> payment system, your credits are
+              deducted only as you consume resources, ensuring you pay exactly
+              for what you use.
             </p>
             <div tw="px-0 mt-12 mb-6 min-h-[6rem] relative">
               <NoisyContainer>
-                <NodesTable
-                  columns={columns}
-                  data={nodeData}
-                  rowProps={() => ({ className: '_active' })}
-                />
-                <div tw="mt-6">
-                  {!node && (
-                    <>
-                      <ButtonWithInfoTooltip
-                        ref={manuallySelectButtonRef}
-                        type="button"
-                        kind="functional"
-                        variant="warning"
-                        size="md"
-                        disabled={manuallySelectCRNDisabled}
-                        tooltipContent={manuallySelectCRNDisabledMessage}
-                        onClick={handleManuallySelectCRN}
-                      >
-                        Manually select GPU
-                      </ButtonWithInfoTooltip>
-                    </>
-                  )}
-                </div>
+                {node ? (
+                  <>
+                    <NodesTable
+                      columns={columns}
+                      data={nodeData}
+                      rowProps={() => ({ className: '_active' })}
+                    />
+                    <div tw="mt-4 flex items-center gap-2 opacity-60">
+                      <Icon name="info-circle" size="sm" />
+                      <span className="tp-body3">
+                        Auto-selected best CRN with this GPU (
+                        {compatibleNodesCount} compatible nodes)
+                      </span>
+                    </div>
+                  </>
+                ) : (
+                  <div tw="p-6 text-center">
+                    <p tw="mb-4 opacity-60">No GPU selected yet</p>
+                    <ButtonWithInfoTooltip
+                      ref={manuallySelectButtonRef}
+                      type="button"
+                      kind="functional"
+                      variant="warning"
+                      size="md"
+                      disabled={manuallySelectCRNDisabled}
+                      tooltipContent={manuallySelectCRNDisabledMessage}
+                      onClick={handleManuallySelectCRN}
+                    >
+                      Select GPU
+                    </ButtonWithInfoTooltip>
+                  </div>
+                )}
               </NoisyContainer>
             </div>
           </CenteredContainer>
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={1}>
+            <CompositeSectionTitle number={2}>
               Select your tier
             </CompositeSectionTitle>
             <p>
               Please select one of the available instance tiers as a base for
-              your VM. You will be able to customize the volumes further below
-              in the form.
+              your VM. Tiers are filtered based on your selected GPU.
             </p>
 
             <div tw="px-0 my-6 relative">
@@ -195,10 +203,11 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
                 gpuModel={node?.selectedGpu?.model}
                 isPersistent
                 nodeSpecs={nodeSpecs}
+                aggregatedSpecs={aggregatedSpecs}
               >
                 {!node && (
                   <div tw="mt-6 text-center">
-                    First select your node in the previous step
+                    First select your GPU in the previous step
                   </div>
                 )}
               </SelectInstanceSpecs>
@@ -207,7 +216,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={2}>
+            <CompositeSectionTitle number={3}>
               Choose an image
             </CompositeSectionTitle>
             <p>
@@ -221,7 +230,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={3}>
+            <CompositeSectionTitle number={4}>
               Configure SSH Key
             </CompositeSectionTitle>
             <p>
@@ -237,7 +246,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={4}>
+            <CompositeSectionTitle number={5}>
               Name and tags
             </CompositeSectionTitle>
             <p tw="mb-6">
@@ -254,13 +263,13 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         </section>
         <section tw="px-0 pt-20 pb-6 md:py-10">
           <CenteredContainer>
-            <CompositeSectionTitle number={5}>
+            <CompositeSectionTitle number={6}>
               Advanced Configuration Options
             </CompositeSectionTitle>
             <p tw="mb-6">
               Customize your GPU Instance with our Advanced Configuration
-              Options. Add volumes and custom domains to meet your specific
-              needs.
+              Options. Add volumes, custom domains, or select a specific CRN
+              node.
             </p>
             <div tw="px-0 my-6">
               <div tw="mb-4">
@@ -292,6 +301,27 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
                     control={control}
                     entityType={EntityDomainType.Instance}
                   />
+                </SwitchToggleContainer>
+              </div>
+              <div tw="mb-4">
+                <SwitchToggleContainer label="Custom Node Selection">
+                  <TextGradient forwardedAs="h2" type="h6" color="main0">
+                    CRN Node Selection
+                  </TextGradient>
+                  <p tw="mb-6">
+                    By default, the best performing CRN node with your selected
+                    GPU is automatically chosen. You can manually select a
+                    different node with the same GPU below if needed.
+                  </p>
+                  {node && (
+                    <NoisyContainer>
+                      <NodesTable
+                        columns={columns}
+                        data={nodeData}
+                        rowProps={() => ({ className: '_active' })}
+                      />
+                    </NoisyContainer>
+                  )}
                 </SwitchToggleContainer>
               </div>
             </div>
@@ -338,11 +368,30 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
         width="80rem"
         header=""
         content={
-          <CRNList
-            enableGpu
-            selected={selectedNode}
-            onSelectedChange={setSelectedNode}
-          />
+          <>
+            {node?.selectedGpu?.model && (
+              <NoisyContainer tw="mb-6 p-4">
+                <div tw="flex items-start gap-3">
+                  <Icon
+                    name="warning"
+                    tw="text-orange-500 flex-shrink-0 mt-0.5"
+                  />
+                  <p className="tp-body2">
+                    The node list below is filtered to show only{' '}
+                    <Strong>{compatibleNodesCount}</Strong> nodes with{' '}
+                    <Strong>{node.selectedGpu.model}</Strong> GPU compatible
+                    with your selected tier.
+                  </p>
+                </div>
+              </NoisyContainer>
+            )}
+            <CRNList
+              enableGpu
+              selected={selectedNode}
+              onSelectedChange={setSelectedNode}
+              filterBySpecs={node ? values.specs : undefined}
+            />
+          </>
         }
         footer={
           <div tw="w-full flex justify-end">
@@ -373,7 +422,7 @@ export default function NewGpuInstancePage({ mainRef }: PageProps) {
             <div tw="flex items-center gap-4 max-w-md mb-8">
               <Checkbox
                 onChange={handleCheckTermsAndConditions}
-                checked={values.termsAndConditions}
+                checked={!!values.termsAndConditions}
               />
               <div className="tp-body">
                 I have read, understood, and agree to the{' '}

--- a/src/components/pages/console/gpuInstance/NewGpuInstancePage/hook.ts
+++ b/src/components/pages/console/gpuInstance/NewGpuInstancePage/hook.ts
@@ -266,7 +266,7 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
     : ''
   const stableSpecs = useStableValue(formValues.specs, specsKey)
 
-  const { autoSelectedNode, compatibleNodes } = useAutoSelectNode({
+  const { autoSelectedNode, compatibleNodesCount } = useAutoSelectNode({
     selectedSpecs: stableSpecs,
     validNodes,
     gpuModel,
@@ -506,7 +506,7 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
     termsAndConditions,
     shouldRequestTermsAndConditions,
     aggregatedSpecs,
-    compatibleNodesCount: compatibleNodes.length,
+    compatibleNodesCount,
     manualNodeOverride,
     handleManuallySelectCRN,
     handleSelectNode,

--- a/src/components/pages/console/instance/NewInstancePage/cmp.tsx
+++ b/src/components/pages/console/instance/NewInstancePage/cmp.tsx
@@ -166,31 +166,6 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                 aggregatedSpecs={aggregatedSpecs}
                 showOpenClawSpotlight
               />
-
-              {/* Auto-selected node info */}
-              {node && (
-                <NoisyContainer tw="mt-6">
-                  <div tw="flex items-center gap-4">
-                    <Icon name="server" size="lg" tw="opacity-60" />
-                    <div tw="flex-1">
-                      <p className="tp-body2" tw="opacity-60 mb-1">
-                        Auto-selected CRN ({compatibleNodesCount} compatible
-                        nodes)
-                      </p>
-                      <div tw="flex items-center gap-4">
-                        <NodeName
-                          hash={node.hash}
-                          name={node.name}
-                          picture={node.picture}
-                          ImageCmp={Image}
-                          apiServer={apiServer}
-                        />
-                        <NodeScore score={node.score} />
-                      </div>
-                    </div>
-                  </div>
-                </NoisyContainer>
-              )}
             </div>
           </CenteredContainer>
         </section>
@@ -361,49 +336,51 @@ export default function NewInstancePage({ mainRef }: PageProps) {
       </Form>
 
       {/* Node List Modal */}
-      <Modal
-        open={selectedModal === 'node-list'}
-        onClose={handleCloseModal}
-        width="80rem"
-        header=""
-        content={
-          <>
-            <NoisyContainer tw="mb-6 p-4">
-              <div tw="flex items-start gap-3">
-                <Icon
-                  name="warning"
-                  tw="text-orange-500 flex-shrink-0 mt-0.5"
-                />
-                <p className="tp-body2">
-                  The node list below is filtered to show only{' '}
-                  <Strong>{compatibleNodesCount}</Strong> nodes compatible with
-                  your selected tier. To see other nodes, change your tier
-                  selection.
-                </p>
-              </div>
-            </NoisyContainer>
-            <CRNList
-              selected={selectedNode}
-              onSelectedChange={setSelectedNode}
-              filterBySpecs={values.specs}
-            />
-          </>
-        }
-        footer={
-          <div tw="w-full flex justify-end">
-            <Button
-              type="button"
-              variant="primary"
-              size="md"
-              onClick={handleSelectNode}
-              disabled={!selectedNode}
-              tw="ml-auto!"
-            >
-              Continue
-            </Button>
-          </div>
-        }
-      />
+      {selectedModal === 'node-list' && (
+        <Modal
+          open
+          onClose={handleCloseModal}
+          width="80rem"
+          header=""
+          content={
+            <>
+              <NoisyContainer tw="mb-6 p-4">
+                <div tw="flex items-start gap-3">
+                  <Icon
+                    name="warning"
+                    tw="text-orange-500 flex-shrink-0 mt-0.5"
+                  />
+                  <p className="tp-body2">
+                    The node list below is filtered to show only{' '}
+                    <Strong>{compatibleNodesCount}</Strong> nodes compatible
+                    with your selected tier. To see other nodes, change your
+                    tier selection.
+                  </p>
+                </div>
+              </NoisyContainer>
+              <CRNList
+                selected={selectedNode}
+                onSelectedChange={setSelectedNode}
+                filterBySpecs={values.specs}
+              />
+            </>
+          }
+          footer={
+            <div tw="w-full flex justify-end">
+              <Button
+                type="button"
+                variant="primary"
+                size="md"
+                onClick={handleSelectNode}
+                disabled={!selectedNode}
+                tw="ml-auto!"
+              >
+                Continue
+              </Button>
+            </div>
+          }
+        />
+      )}
 
       {/* Terms and Conditions Modal */}
       <Modal

--- a/src/components/pages/console/instance/NewInstancePage/hook.ts
+++ b/src/components/pages/console/instance/NewInstancePage/hook.ts
@@ -59,6 +59,7 @@ import {
 } from '@/hooks/common/useAggregatedNodeSpecs'
 import { useAutoSelectNode } from '@/hooks/common/useAutoSelectNode'
 import { useRequestCRNSpecs } from '@/hooks/common/useRequestEntity/useRequestCRNSpecs'
+import { useStableValue } from '@/hooks/common/useStableValue'
 
 export type NewInstanceFormState = NameAndTagsField & {
   image: InstanceImageField
@@ -252,8 +253,14 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   // -------------------------
   // Auto-select node based on selected tier
 
+  // Stabilize specs to prevent infinite loops from object reference changes
+  const specsKey = formValues.specs
+    ? `${formValues.specs.cpu}-${formValues.specs.ram}-${formValues.specs.storage}`
+    : ''
+  const stableSpecs = useStableValue(formValues.specs, specsKey)
+
   const { autoSelectedNode, compatibleNodes } = useAutoSelectNode({
-    selectedSpecs: formValues.specs,
+    selectedSpecs: stableSpecs,
     validNodes,
     enabled: !manualNodeOverride,
   })
@@ -444,10 +451,11 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     setValue('systemVolume.size', newSize)
   }, [storage, prevStorage, setValue, systemVolumeSize])
 
-  // @note: Set nodeSpecs
+  // @note: Set nodeSpecs (only when the hash changes to avoid infinite loops)
+  const stableNodeSpecs = useStableValue(nodeSpecs, nodeSpecs?.hash)
   useEffect(() => {
-    setValue('nodeSpecs', nodeSpecs)
-  }, [nodeSpecs, setValue])
+    setValue('nodeSpecs', stableNodeSpecs)
+  }, [stableNodeSpecs, setValue])
 
   // @note: Reset manual override when tier changes (user needs to re-select node)
   const prevSpecs = usePrevious(formValues.specs)

--- a/src/components/pages/console/instance/NewInstancePage/hook.ts
+++ b/src/components/pages/console/instance/NewInstancePage/hook.ts
@@ -1,12 +1,5 @@
 import { useAppState } from '@/contexts/appState'
-import {
-  FormEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import Router, { useRouter } from 'next/router'
 import { useForm } from '@/hooks/common/useForm'
 import {
@@ -34,7 +27,6 @@ import {
   UseEntityCostReturn,
   UseInstanceCostProps,
 } from '@/hooks/common/useEntityCost'
-import { useRequestCRNSpecs } from '@/hooks/common/useRequestEntity/useRequestCRNSpecs'
 import { CRNSpecs, NodeLastVersions, NodeManager } from '@/domain/node'
 import {
   stepsCatalog,
@@ -61,6 +53,12 @@ import {
   useInsufficientFunds,
   InsufficientFundsInfo,
 } from '@/hooks/common/useInsufficientFunds'
+import {
+  useAggregatedNodeSpecs,
+  AggregatedNodeSpecs,
+} from '@/hooks/common/useAggregatedNodeSpecs'
+import { useAutoSelectNode } from '@/hooks/common/useAutoSelectNode'
+import { useRequestCRNSpecs } from '@/hooks/common/useRequestEntity/useRequestCRNSpecs'
 
 export type NewInstanceFormState = NameAndTagsField & {
   image: InstanceImageField
@@ -85,7 +83,7 @@ export type UseNewInstancePageReturn = {
   createInstanceButtonTitle: string
   minimumBalanceNeeded: number
   insufficientFundsInfo?: InsufficientFundsInfo
-  values: any
+  values: NewInstanceFormState
   control: Control<any>
   errors: FieldErrors<NewInstanceFormState>
   cost: UseEntityCostReturn
@@ -98,6 +96,9 @@ export type UseNewInstancePageReturn = {
   setSelectedNode: (hash?: CRNSpecs) => void
   termsAndConditions?: TermsAndConditions
   shouldRequestTermsAndConditions: boolean
+  aggregatedSpecs?: AggregatedNodeSpecs
+  compatibleNodesCount: number
+  manualNodeOverride: boolean
   handleManuallySelectCRN: () => void
   handleSelectNode: () => void
   handleRequestTermsAndConditionsAgreement: () => void
@@ -121,45 +122,37 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   })
 
   const router = useRouter()
-  const { crn: queryCRN } = router.query
 
-  const nodeRef = useRef<CRNSpecs | undefined>(undefined)
   const [selectedNode, setSelectedNode] = useState<CRNSpecs>()
   const [selectedModal, setSelectedModal] = useState<Modal>()
+  const [manualNodeOverride, setManualNodeOverride] = useState(false)
+  const [manuallySelectedNode, setManuallySelectedNode] = useState<CRNSpecs>()
 
   // -------------------------
-  // Request CRNs specs
+  // Request CRNs specs and aggregated specs
   const { specs } = useRequestCRNSpecs()
   const { lastVersion } = useRequestCRNLastVersion()
-
-  // @note: Set node depending on CRN
-  const node: CRNSpecs | undefined = useMemo(() => {
-    if (!specs) return
-    if (!queryCRN) return nodeRef.current
-    if (typeof queryCRN !== 'string') return nodeRef.current
-
-    nodeRef.current = specs[queryCRN]?.data as CRNSpecs
-    return nodeRef.current
-  }, [specs, queryCRN])
-
-  const nodeSpecs = useMemo(() => {
-    if (!node) return
-    if (!specs) return
-
-    return specs[node.hash]?.data
-  }, [specs, node])
-
-  // -------------------------
-  // Terms and conditions
-
-  const { termsAndConditions } = useFetchTermsAndConditions({
-    termsAndConditionsMessageHash: node?.terms_and_conditions,
-  })
+  const { aggregatedSpecs, validNodes } = useAggregatedNodeSpecs()
 
   // -------------------------
   // Tiers
 
   const { defaultTiers } = useDefaultTiers({ type: EntityType.Instance })
+
+  // -------------------------
+  // Setup form
+
+  const defaultValues: Partial<NewInstanceFormState> = useMemo(
+    () => ({
+      ...defaultNameAndTags,
+      image: defaultInstanceImage,
+      specs: defaultTiers[0],
+      systemVolume: { size: defaultTiers[0]?.storage },
+      paymentMethod: PaymentMethod.Credit,
+      termsAndConditions: undefined,
+    }),
+    [defaultTiers],
+  )
 
   // -------------------------
   // Checkout flow
@@ -168,10 +161,12 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   const { next, stop } = useCheckoutNotification({})
 
   const onSubmit = useCallback(
-    async (state: NewInstanceFormState) => {
+    async (state: NewInstanceFormState, node: CRNSpecs | undefined) => {
       if (!manager) throw Err.ConnectYourWallet
       if (!account) throw Err.InvalidAccount
       if (!node) throw Err.InvalidNode
+
+      const nodeSpecs = specs[node.hash]?.data
       if (!nodeSpecs) throw Err.InvalidCRNSpecs
 
       const [minSpecs] = defaultTiers
@@ -230,8 +225,7 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     [
       manager,
       account,
-      node,
-      nodeSpecs,
+      specs,
       defaultTiers,
       blockchain,
       handleConnect,
@@ -241,21 +235,6 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     ],
   )
 
-  // -------------------------
-  // Setup form
-
-  const defaultValues: Partial<NewInstanceFormState> = useMemo(
-    () => ({
-      ...defaultNameAndTags,
-      image: defaultInstanceImage,
-      specs: defaultTiers[0],
-      systemVolume: { size: defaultTiers[0]?.storage },
-      paymentMethod: PaymentMethod.Credit,
-      termsAndConditions: undefined,
-    }),
-    [defaultTiers],
-  )
-
   const {
     control,
     handleSubmit,
@@ -263,7 +242,7 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     setValue,
   } = useForm({
     defaultValues,
-    onSubmit,
+    onSubmit: (state: NewInstanceFormState) => onSubmit(state, node),
     resolver: zodResolver(InstanceManager.addSchema),
     readyDeps: [],
   })
@@ -271,8 +250,39 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   const formValues = useWatch({ control }) as NewInstanceFormState
 
   // -------------------------
+  // Auto-select node based on selected tier
 
-  const { storage } = formValues.specs
+  const { autoSelectedNode, compatibleNodes } = useAutoSelectNode({
+    selectedSpecs: formValues.specs,
+    validNodes,
+    enabled: !manualNodeOverride,
+  })
+
+  // Final node: manual override takes precedence over auto-selected
+  const node: CRNSpecs | undefined = useMemo(() => {
+    if (manualNodeOverride && manuallySelectedNode) {
+      return manuallySelectedNode
+    }
+    return autoSelectedNode
+  }, [manualNodeOverride, manuallySelectedNode, autoSelectedNode])
+
+  const nodeSpecs = useMemo(() => {
+    if (!node) return
+    if (!specs) return
+
+    return specs[node.hash]?.data
+  }, [specs, node])
+
+  // -------------------------
+  // Terms and conditions
+
+  const { termsAndConditions } = useFetchTermsAndConditions({
+    termsAndConditionsMessageHash: node?.terms_and_conditions,
+  })
+
+  // -------------------------
+
+  const { storage } = formValues.specs || {}
   const { size: systemVolumeSize } = formValues.systemVolume
 
   const payment: PaymentConfiguration = useMemo(() => {
@@ -373,15 +383,10 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
     if (!selectedNode) return
 
-    const { hash: selectedNodeHash } = selectedNode
-    const { crn: queryCRN, ...rest } = router.query
-
-    if (queryCRN === selectedNodeHash) return
-
-    Router.replace({
-      query: selectedNode ? { ...rest, crn: selectedNodeHash } : rest,
-    })
-  }, [router.query, selectedNode])
+    // Set manual override and the selected node
+    setManualNodeOverride(true)
+    setManuallySelectedNode(selectedNode)
+  }, [selectedNode])
 
   const handleManuallySelectCRN = useCallback(() => {
     setSelectedModal('node-list')
@@ -424,18 +429,6 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   // -------------------------
   // Effects
 
-  // @note: Updates url depending on payment method
-  useEffect(() => {
-    if (!node) return
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { crn, ...rest } = Router.query
-
-    Router.replace({
-      query: { ...rest, crn: node.hash },
-    })
-  }, [node])
-
   const prevStorage = usePrevious(storage)
 
   // @note: Change default System fake volume size when the specs changes
@@ -455,6 +448,21 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   useEffect(() => {
     setValue('nodeSpecs', nodeSpecs)
   }, [nodeSpecs, setValue])
+
+  // @note: Reset manual override when tier changes (user needs to re-select node)
+  const prevSpecs = usePrevious(formValues.specs)
+  useEffect(() => {
+    if (!formValues.specs || !prevSpecs) return
+
+    // If tier changed, reset manual override so auto-select kicks in
+    if (
+      formValues.specs.cpu !== prevSpecs.cpu ||
+      formValues.specs.ram !== prevSpecs.ram
+    ) {
+      setManualNodeOverride(false)
+      setManuallySelectedNode(undefined)
+    }
+  }, [formValues.specs, prevSpecs])
 
   return {
     address,
@@ -478,6 +486,9 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     setSelectedNode,
     termsAndConditions,
     shouldRequestTermsAndConditions,
+    aggregatedSpecs,
+    compatibleNodesCount: compatibleNodes.length,
+    manualNodeOverride,
     handleManuallySelectCRN,
     handleSelectNode,
     handleSubmit: handleFormSubmit,

--- a/src/components/pages/console/instance/NewInstancePage/hook.ts
+++ b/src/components/pages/console/instance/NewInstancePage/hook.ts
@@ -259,7 +259,7 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     : ''
   const stableSpecs = useStableValue(formValues.specs, specsKey)
 
-  const { autoSelectedNode, compatibleNodes } = useAutoSelectNode({
+  const { autoSelectedNode, compatibleNodesCount } = useAutoSelectNode({
     selectedSpecs: stableSpecs,
     validNodes,
     enabled: !manualNodeOverride,
@@ -495,7 +495,7 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     termsAndConditions,
     shouldRequestTermsAndConditions,
     aggregatedSpecs,
-    compatibleNodesCount: compatibleNodes.length,
+    compatibleNodesCount,
     manualNodeOverride,
     handleManuallySelectCRN,
     handleSelectNode,

--- a/src/hooks/common/useAggregatedNodeSpecs.ts
+++ b/src/hooks/common/useAggregatedNodeSpecs.ts
@@ -4,6 +4,7 @@ import { useRequestCRNSpecs } from '@/hooks/common/useRequestEntity/useRequestCR
 import { useCostManager } from './useManager/useCostManager'
 import { useLocalRequest } from '@aleph-front/core'
 import { compareVersion } from '@/helpers/utils'
+import { useStableValue } from './useStableValue'
 
 export type AggregatedNodeSpecs = {
   maxCpu: number
@@ -46,7 +47,7 @@ export function useAggregatedNodeSpecs(): UseAggregatedNodeSpecsReturn {
   }, [crnSpecs])
 
   // Filter valid nodes (IPV6 check, version requirements)
-  const validNodes = useMemo(() => {
+  const filteredNodes = useMemo(() => {
     if (!settingsAggregate?.lastCrnVersion) return []
 
     const minVersion = settingsAggregate.lastCrnVersion
@@ -74,6 +75,10 @@ export function useAggregatedNodeSpecs(): UseAggregatedNodeSpecsReturn {
       return true
     })
   }, [allNodes, settingsAggregate])
+
+  // Stabilize validNodes to prevent infinite loops - only update when node hashes change
+  const validNodesKey = filteredNodes.map((n) => n.hash).join(',')
+  const validNodes = useStableValue(filteredNodes, validNodesKey)
 
   // Compute aggregated (max) specs across all valid nodes
   const aggregatedSpecs = useMemo(() => {

--- a/src/hooks/common/useAggregatedNodeSpecs.ts
+++ b/src/hooks/common/useAggregatedNodeSpecs.ts
@@ -1,0 +1,115 @@
+import { useMemo } from 'react'
+import { CRNSpecs } from '@/domain/node'
+import { useRequestCRNSpecs } from '@/hooks/common/useRequestEntity/useRequestCRNSpecs'
+import { useCostManager } from './useManager/useCostManager'
+import { useLocalRequest } from '@aleph-front/core'
+import { compareVersion } from '@/helpers/utils'
+
+export type AggregatedNodeSpecs = {
+  maxCpu: number
+  maxRamKB: number
+  maxDiskKB: number
+  gpuModels: string[]
+}
+
+export type UseAggregatedNodeSpecsReturn = {
+  aggregatedSpecs: AggregatedNodeSpecs | undefined
+  validNodes: CRNSpecs[]
+  loading: boolean
+}
+
+export function useAggregatedNodeSpecs(): UseAggregatedNodeSpecsReturn {
+  const { specs: crnSpecs, loading: isLoadingSpecs } = useRequestCRNSpecs()
+  const costManager = useCostManager()
+
+  const { data: settingsAggregate, loading: isLoadingSettings } =
+    useLocalRequest({
+      doRequest: () => {
+        return costManager
+          ? costManager.getSettingsAggregate()
+          : Promise.resolve(undefined)
+      },
+      onSuccess: () => null,
+      onError: () => null,
+      flushData: true,
+      triggerOnMount: true,
+      triggerDeps: [costManager],
+    })
+
+  const loading = isLoadingSpecs || isLoadingSettings
+
+  // Extract all CRN specs from the RequestState objects
+  const allNodes = useMemo(() => {
+    return Object.values(crnSpecs)
+      .map((spec) => spec.data)
+      .filter(Boolean) as CRNSpecs[]
+  }, [crnSpecs])
+
+  // Filter valid nodes (IPV6 check, version requirements)
+  const validNodes = useMemo(() => {
+    if (!settingsAggregate?.lastCrnVersion) return []
+
+    const minVersion = settingsAggregate.lastCrnVersion
+
+    return allNodes.filter((node) => {
+      // Check IPV6 support
+      // @note: Backend sometimes returns `result` instead of `vm`
+      const hasValidIPV6 =
+        node.ipv6_check?.vm || node.ipv6_check?.result || false
+      if (!hasValidIPV6) return false
+
+      // Check version requirements
+      const nodeVersion = node.version || ''
+      if (!nodeVersion) return false
+      if (!compareVersion(nodeVersion, minVersion)) return false
+
+      // Check basic specs exist
+      if (
+        !node.cpu?.count ||
+        !node.mem?.available_kB ||
+        !node.disk?.available_kB
+      )
+        return false
+
+      return true
+    })
+  }, [allNodes, settingsAggregate])
+
+  // Compute aggregated (max) specs across all valid nodes
+  const aggregatedSpecs = useMemo(() => {
+    if (validNodes.length === 0) return undefined
+
+    const gpuModelsSet = new Set<string>()
+
+    const result = validNodes.reduce(
+      (acc, node) => {
+        acc.maxCpu = Math.max(acc.maxCpu, node.cpu?.count || 0)
+        acc.maxRamKB = Math.max(acc.maxRamKB, node.mem?.available_kB || 0)
+        acc.maxDiskKB = Math.max(acc.maxDiskKB, node.disk?.available_kB || 0)
+
+        // Collect GPU models
+        node.compatible_available_gpus?.forEach((gpu) => {
+          if (gpu.model) gpuModelsSet.add(gpu.model)
+        })
+
+        return acc
+      },
+      {
+        maxCpu: 0,
+        maxRamKB: 0,
+        maxDiskKB: 0,
+        gpuModels: [] as string[],
+      },
+    )
+
+    result.gpuModels = Array.from(gpuModelsSet).sort()
+
+    return result
+  }, [validNodes])
+
+  return {
+    aggregatedSpecs,
+    validNodes,
+    loading,
+  }
+}

--- a/src/hooks/common/useAutoSelectNode.ts
+++ b/src/hooks/common/useAutoSelectNode.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import { CRNSpecs, NodeManager, ReducedCRNSpecs } from '@/domain/node'
+
+export type UseAutoSelectNodeProps = {
+  selectedSpecs: ReducedCRNSpecs | undefined
+  validNodes: CRNSpecs[]
+  gpuModel?: string
+  enabled?: boolean
+}
+
+export type UseAutoSelectNodeReturn = {
+  autoSelectedNode: CRNSpecs | undefined
+  compatibleNodes: CRNSpecs[]
+}
+
+export function useAutoSelectNode({
+  selectedSpecs,
+  validNodes,
+  gpuModel,
+  enabled = true,
+}: UseAutoSelectNodeProps): UseAutoSelectNodeReturn {
+  // Filter nodes that can support the selected tier
+  const compatibleNodes = useMemo(() => {
+    if (!selectedSpecs) return []
+    if (!validNodes.length) return []
+
+    let nodes = validNodes.filter((node) =>
+      NodeManager.validateMinNodeSpecs(selectedSpecs, node),
+    )
+
+    // For GPU instances, also filter by GPU model
+    if (gpuModel) {
+      nodes = nodes.filter((node) =>
+        node.compatible_available_gpus?.some((gpu) => gpu.model === gpuModel),
+      )
+
+      // Flatten to create one entry per GPU device of matching model
+      nodes = nodes.flatMap((node) => {
+        const matchingGpus =
+          node.compatible_available_gpus?.filter(
+            (gpu) => gpu.model === gpuModel,
+          ) || []
+
+        return matchingGpus.map((gpu) => ({
+          ...node,
+          selectedGpu: gpu,
+        }))
+      })
+    }
+
+    // Sort by score (descending) - highest score first
+    return nodes.sort((a, b) => (b.score || 0) - (a.score || 0))
+  }, [selectedSpecs, validNodes, gpuModel])
+
+  // Auto-select the highest-scoring compatible node
+  const autoSelectedNode = useMemo(() => {
+    if (!enabled) return undefined
+    if (compatibleNodes.length === 0) return undefined
+
+    return compatibleNodes[0]
+  }, [enabled, compatibleNodes])
+
+  return {
+    autoSelectedNode,
+    compatibleNodes,
+  }
+}

--- a/src/hooks/common/useAutoSelectNode.ts
+++ b/src/hooks/common/useAutoSelectNode.ts
@@ -12,6 +12,7 @@ export type UseAutoSelectNodeProps = {
 export type UseAutoSelectNodeReturn = {
   autoSelectedNode: CRNSpecs | undefined
   compatibleNodes: CRNSpecs[]
+  compatibleNodesCount: number
 }
 
 export function useAutoSelectNode({
@@ -57,6 +58,12 @@ export function useAutoSelectNode({
   const compatibleNodesKey = filteredNodes.map((n) => n.hash).join(',')
   const compatibleNodes = useStableValue(filteredNodes, compatibleNodesKey)
 
+  // Count distinct nodes (not GPU-node pairs, which may be duplicated via flatMap)
+  const compatibleNodesCount = useMemo(
+    () => new Set(filteredNodes.map((n) => n.hash)).size,
+    [filteredNodes],
+  )
+
   // Compute the auto-selected node
   const selectedNode = useMemo(() => {
     if (!enabled) return undefined
@@ -70,5 +77,6 @@ export function useAutoSelectNode({
   return {
     autoSelectedNode,
     compatibleNodes,
+    compatibleNodesCount,
   }
 }

--- a/src/hooks/common/useCRNList.ts
+++ b/src/hooks/common/useCRNList.ts
@@ -5,7 +5,12 @@ import {
   useRequestCRNSpecs,
 } from '@/hooks/common/useRequestEntity/useRequestCRNSpecs'
 import { useNodeManager } from '@/hooks/common/useManager/useNodeManager'
-import { CRNSpecs, StreamNotSupportedIssue } from '@/domain/node'
+import {
+  CRNSpecs,
+  NodeManager,
+  ReducedCRNSpecs,
+  StreamNotSupportedIssue,
+} from '@/domain/node'
 import {
   DropdownProps,
   useDebounceState,
@@ -35,6 +40,7 @@ export type UseCRNListProps = {
   selected?: CRNSpecs
   onSelectedChange: (selected: CRNSpecs) => void
   enableGpu?: boolean
+  filterBySpecs?: ReducedCRNSpecs
 }
 
 export type UseCRNListReturn = UseCRNListProps &
@@ -42,6 +48,7 @@ export type UseCRNListReturn = UseCRNListProps &
   UseRequestCRNSpecsReturn & {
     nodesIssues?: StreamSupportedIssues
     filteredNodes?: CRNSpecs[]
+    totalCompatibleNodes: number
     filterOptions: CRNListFilterOptions
     loadItemsDisabled: boolean
     handleLoadItems: () => Promise<void>
@@ -59,7 +66,7 @@ export type UseCRNListReturn = UseCRNListProps &
   }
 
 export function useCRNList(props: UseCRNListProps): UseCRNListReturn {
-  const { enableGpu } = props
+  const { enableGpu, filterBySpecs } = props
 
   const nodeManager = useNodeManager()
   const costManager = useCostManager()
@@ -274,6 +281,13 @@ export function useCRNList(props: UseCRNListProps): UseCRNListReturn {
   const filteredNodes = useMemo(() => {
     try {
       return validCreditNodes?.filter((node) => {
+        // Filter by tier specs if provided (only show nodes compatible with selected tier)
+        if (filterBySpecs) {
+          if (!NodeManager.validateMinNodeSpecs(filterBySpecs, node)) {
+            return false
+          }
+        }
+
         if (gpuFilter) {
           if (node.selectedGpu?.model !== gpuFilter) return false
         }
@@ -297,7 +311,14 @@ export function useCRNList(props: UseCRNListProps): UseCRNListReturn {
     } finally {
       setIsLoadingList(false)
     }
-  }, [gpuFilter, cpuFilter, hddFilter, ramFilter, validCreditNodes])
+  }, [
+    filterBySpecs,
+    gpuFilter,
+    cpuFilter,
+    hddFilter,
+    ramFilter,
+    validCreditNodes,
+  ])
 
   const sortedNodes = useMemo(() => {
     if (!filteredNodes) return
@@ -355,6 +376,9 @@ export function useCRNList(props: UseCRNListProps): UseCRNListReturn {
     resetDeps: [baseFilteredNodes],
   })
 
+  // Total number of nodes compatible with the filter specs (before pagination)
+  const totalCompatibleNodes = sortedFilteredNodes?.length || 0
+
   return {
     ...props,
     lastVersion,
@@ -362,6 +386,7 @@ export function useCRNList(props: UseCRNListProps): UseCRNListReturn {
     loading,
     nodesIssues,
     filteredNodes: paginatedSortedFilteredNodes,
+    totalCompatibleNodes,
     filterOptions,
     loadItemsDisabled,
     handleLoadItems,

--- a/src/hooks/common/useRequestEntity/useRequestCRNSpecs.ts
+++ b/src/hooks/common/useRequestEntity/useRequestCRNSpecs.ts
@@ -53,17 +53,17 @@ export function useRequestCRNSpecs(
       const loadAllSpecs = async () => {
         const crnSpecs = await nodeManager.getAllCRNsSpecs()
 
+        // Batch all specs into a single state update to prevent infinite loops
+        const newSpecs: Record<string, RequestState<CRNSpecs>> = {}
         crnSpecs.forEach((spec) => {
-          setSpecs((prev) => ({
-            ...prev,
-            [spec.hash]: {
-              data: spec,
-              loading: false,
-              error: undefined,
-            },
-          }))
+          newSpecs[spec.hash] = {
+            data: spec,
+            loading: false,
+            error: undefined,
+          }
         })
 
+        setSpecs((prev) => ({ ...prev, ...newSpecs }))
         setLoading(false)
       }
 

--- a/src/hooks/common/useStableValue.ts
+++ b/src/hooks/common/useStableValue.ts
@@ -1,0 +1,24 @@
+import { useRef, useMemo } from 'react'
+
+/**
+ * Returns a stable reference to a value that only updates when the cache key changes.
+ * This is useful for avoiding infinite loops in useEffect dependencies when dealing
+ * with objects that have the same logical value but different references.
+ *
+ * @param value The value to stabilize
+ * @param cacheKey A primitive value (string, number, etc.) that represents when the value should update
+ * @returns The stabilized value
+ */
+export function useStableValue<T>(
+  value: T,
+  cacheKey: string | number | undefined,
+): T {
+  const valueRef = useRef<T>(value)
+
+  useMemo(() => {
+    valueRef.current = value
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheKey])
+
+  return valueRef.current
+}

--- a/src/hooks/common/useStableValue.ts
+++ b/src/hooks/common/useStableValue.ts
@@ -1,4 +1,4 @@
-import { useRef, useMemo } from 'react'
+import { useRef } from 'react'
 
 /**
  * Returns a stable reference to a value that only updates when the cache key changes.
@@ -14,11 +14,12 @@ export function useStableValue<T>(
   cacheKey: string | number | undefined,
 ): T {
   const valueRef = useRef<T>(value)
+  const keyRef = useRef(cacheKey)
 
-  useMemo(() => {
+  if (keyRef.current !== cacheKey) {
+    keyRef.current = cacheKey
     valueRef.current = value
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cacheKey])
+  }
 
   return valueRef.current
 }


### PR DESCRIPTION
## Summary
- Reverse the node selection flow in instance/GPU creation forms: users now select a tier first, and a compatible CRN node is auto-selected
- Move manual node selection to the Advanced Configuration section (collapsed by default)
- Filter available tiers by the union of all node capabilities instead of a single selected node
- Add warning banner when viewing the filtered node list in the modal

## Test plan
- [ ] Navigate to `/console/computing/instance/new` and verify tiers display without selecting a node first
- [ ] Select a tier and confirm a node is auto-selected (highest score among compatible nodes)
- [ ] Verify the auto-selected node info displays below the tier selection
- [ ] Expand "Custom Node Selection" in Advanced Configuration and verify the node list modal shows a warning banner
- [ ] Change the tier and verify the auto-selected node updates accordingly
- [ ] Manually select a different node and confirm it persists until tier is changed
- [ ] Complete form submission and verify instance is created successfully
- [ ] Repeat all steps for GPU instances at `/console/computing/gpu-instance/new`