### PR TITLE
feat: display node hash on CRN and CCN detail pages

### DIFF
--- a/src/components/pages/account/ComputeResourceNodeDetailPage/tabs/OverviewTabContent/cmp.tsx
+++ b/src/components/pages/account/ComputeResourceNodeDetailPage/tabs/OverviewTabContent/cmp.tsx
@@ -170,6 +170,15 @@ export const OverviewTabContent = ({
               }
               big
             />
+            <Card2Field
+              name="NODE HASH"
+              value={
+                <NodeDetailLink textToCopy={node?.hash}>
+                  {node?.hash && ellipseAddress(node?.hash)}
+                </NodeDetailLink>
+              }
+              big
+            />
           </Card2>
           <Card2 title="HARDWARE">
             <Card2Field name="CPU" value={nodeSpecs?.properties?.cpu.vendor} />

--- a/src/components/pages/account/CoreChannelNodeDetailPage/cmp.tsx
+++ b/src/components/pages/account/CoreChannelNodeDetailPage/cmp.tsx
@@ -198,6 +198,15 @@ export const CoreChannelNodeDetailPage = () => {
                     }
                     big
                   />
+                  <Card2Field
+                    name="NODE HASH"
+                    value={
+                      <NodeDetailLink textToCopy={node?.hash}>
+                        {node?.hash && ellipseAddress(node?.hash)}
+                      </NodeDetailLink>
+                    }
+                    big
+                  />
                 </Card2>
                 <Card2 title="ADDITIONAL SETTINGS">
                   <Card2Field


### PR DESCRIPTION
Add a NODE HASH field with copy-to-clipboard button below the ADDRESS field on CRN pages and below the MULTI ADDRESS field on CCN pages.