### PR TITLE
Feat/credits dashboard

### DIFF
--- a/src/components/modals/CreditTransferModal/cmp.tsx
+++ b/src/components/modals/CreditTransferModal/cmp.tsx
@@ -1,0 +1,219 @@
+import React, { memo, useCallback, useState } from 'react'
+import 'twin.macro'
+import { Button, Icon, Modal, TextGradient, TextInput } from '@aleph-front/core'
+import { useCreditTransferModal, useCreditTransferForm } from './hook'
+import { useConnection } from '@/hooks/common/useConnection'
+import { formatCredits } from '@/helpers/utils'
+import SpinnerOverlay from '@/components/common/SpinnerOverlay'
+
+type Recipient = {
+  address: string
+  amount: string
+  expiration: string
+}
+
+const emptyRecipient: Recipient = {
+  address: '',
+  amount: '',
+  expiration: '',
+}
+
+const CreditTransferModal = () => {
+  const { isOpen, handleClose } = useCreditTransferModal()
+  const { handleSubmit, loading, error } = useCreditTransferForm()
+  const { creditBalance } = useConnection({ triggerOnMount: false })
+
+  const [recipients, setRecipients] = useState<Recipient[]>([
+    { ...emptyRecipient },
+  ])
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const handleRecipientChange = useCallback(
+    (index: number, field: keyof Recipient, value: string) => {
+      setRecipients((prev) => {
+        const next = [...prev]
+        next[index] = { ...next[index], [field]: value }
+        return next
+      })
+      setFormError(null)
+    },
+    [],
+  )
+
+  const handleAddRecipient = useCallback(() => {
+    setRecipients((prev) => [...prev, { ...emptyRecipient }])
+  }, [])
+
+  const handleRemoveRecipient = useCallback((index: number) => {
+    setRecipients((prev) => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const validate = useCallback(() => {
+    for (const r of recipients) {
+      if (!r.address || !r.address.startsWith('0x') || r.address.length < 42) {
+        setFormError('Invalid Ethereum address')
+        return false
+      }
+      const amount = Number(r.amount)
+      if (!amount || amount <= 0) {
+        setFormError('Amount must be greater than 0')
+        return false
+      }
+    }
+
+    const totalAmount = recipients.reduce((sum, r) => sum + Number(r.amount), 0)
+
+    if (creditBalance && totalAmount > creditBalance) {
+      setFormError('Total amount exceeds your balance')
+      return false
+    }
+
+    return true
+  }, [recipients, creditBalance])
+
+  const onSubmit = useCallback(async () => {
+    if (!validate()) return
+
+    try {
+      await handleSubmit({
+        recipients: recipients.map((r) => ({
+          address: r.address,
+          amount: Number(r.amount),
+          ...(r.expiration && { expiration: r.expiration }),
+        })),
+      })
+      setRecipients([{ ...emptyRecipient }])
+    } catch (err) {
+      setFormError((err as Error).message)
+    }
+  }, [validate, handleSubmit, recipients])
+
+  const handleModalClose = useCallback(() => {
+    setRecipients([{ ...emptyRecipient }])
+    setFormError(null)
+    handleClose()
+  }, [handleClose])
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={handleModalClose}
+      closeOnCloseButton={false}
+      width="32rem"
+      header={
+        <div>
+          <TextGradient type="h6" forwardedAs="h2" tw="mb-2">
+            Transfer Credits
+          </TextGradient>
+          <p tw="m-0">
+            Send credits to another account. Transfers are processed on the
+            Aleph network.
+          </p>
+          {creditBalance !== undefined && (
+            <p className="tp-body3 text-base2" tw="mt-2">
+              Available: {formatCredits(creditBalance)}
+            </p>
+          )}
+        </div>
+      }
+      content={
+        <div tw="flex flex-col gap-4">
+          {recipients.map((r, index) => (
+            <div
+              key={index}
+              tw="flex flex-col gap-3 pb-4"
+              css={
+                index > 0
+                  ? 'border-top: 1px solid rgba(255,255,255,0.1);padding-top:1rem;'
+                  : ''
+              }
+            >
+              {recipients.length > 1 && (
+                <div tw="flex items-center justify-between">
+                  <span className="tp-body2">Recipient {index + 1}</span>
+                </div>
+              )}
+              <TextInput
+                name={`address-${index}`}
+                label="Recipient Address"
+                placeholder="0x..."
+                value={r.address}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  handleRecipientChange(index, 'address', e.target.value)
+                }
+              />
+              <TextInput
+                name={`amount-${index}`}
+                label="Amount (credits)"
+                placeholder="1000000"
+                type="number"
+                value={r.amount}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  handleRecipientChange(index, 'amount', e.target.value)
+                }
+              />
+              <TextInput
+                name={`expiration-${index}`}
+                label="Expiration (optional)"
+                type="date"
+                value={r.expiration}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  handleRecipientChange(index, 'expiration', e.target.value)
+                }
+              />
+              {recipients.length > 1 && (
+                <div tw="mt-4 pt-6 text-right">
+                  <Button
+                    type="button"
+                    kind="functional"
+                    variant="warning"
+                    size="md"
+                    onClick={() => handleRemoveRecipient(index)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              )}
+            </div>
+          ))}
+
+          <div tw="text-left">
+            <Button
+              type="button"
+              kind="functional"
+              variant="secondary"
+              size="md"
+              onClick={handleAddRecipient}
+            >
+              <Icon name="plus-circle" tw="mr-1" /> Add recipient
+            </Button>
+          </div>
+
+          {(formError || error) && (
+            <p className="tp-body2 text-error" tw="mt-2">
+              <Icon name="exclamation-triangle" tw="mr-2" />
+              {formError || error?.message}
+            </p>
+          )}
+
+          <SpinnerOverlay show={loading} center size="8rem" />
+        </div>
+      }
+      footer={
+        <div tw="flex justify-center">
+          <Button
+            variant="primary"
+            size="md"
+            disabled={loading}
+            onClick={onSubmit}
+          >
+            Confirm Transfer <Icon name="arrow-right" />
+          </Button>
+        </div>
+      }
+    />
+  )
+}
+CreditTransferModal.displayName = 'CreditTransferModal'
+
+export default memo(CreditTransferModal)

--- a/src/components/modals/CreditTransferModal/cmp.tsx
+++ b/src/components/modals/CreditTransferModal/cmp.tsx
@@ -177,15 +177,16 @@ const CreditTransferModal = () => {
             </div>
           ))}
 
-          <div tw="text-left">
+          <div tw="text-center">
             <Button
               type="button"
-              kind="functional"
+              color="main0"
+              kind="gradient"
               variant="secondary"
               size="md"
               onClick={handleAddRecipient}
             >
-              <Icon name="plus-circle" tw="mr-1" /> Add recipient
+              Add recipient <Icon name="plus-circle" />
             </Button>
           </div>
 

--- a/src/components/modals/CreditTransferModal/cmp.tsx
+++ b/src/components/modals/CreditTransferModal/cmp.tsx
@@ -1,103 +1,31 @@
-import React, { memo, useCallback, useState } from 'react'
+import React, { memo } from 'react'
 import 'twin.macro'
 import { Button, Icon, Modal, TextGradient, TextInput } from '@aleph-front/core'
-import { useCreditTransferModal, useCreditTransferForm } from './hook'
-import { useConnection } from '@/hooks/common/useConnection'
+import { useController } from 'react-hook-form'
+import { useCreditTransferModal, useCreditTransferModalForm } from './hook'
 import { formatCredits } from '@/helpers/utils'
+import { CREDITS_PER_USD } from '@/domain/credit'
 import SpinnerOverlay from '@/components/common/SpinnerOverlay'
-
-type Recipient = {
-  address: string
-  amount: string
-  expiration: string
-}
-
-const emptyRecipient: Recipient = {
-  address: '',
-  amount: '',
-  expiration: '',
-}
+import { Form } from '@/components/form/Form'
 
 const CreditTransferModal = () => {
   const { isOpen, handleClose } = useCreditTransferModal()
-  const { handleSubmit, loading, error } = useCreditTransferForm()
-  const { creditBalance } = useConnection({ triggerOnMount: false })
+  const {
+    control,
+    handleSubmit,
+    errors,
+    isSubmitLoading,
+    fieldArray,
+    balanceDollars,
+    handleFillMax,
+  } = useCreditTransferModalForm()
 
-  const [recipients, setRecipients] = useState<Recipient[]>([
-    { ...emptyRecipient },
-  ])
-  const [formError, setFormError] = useState<string | null>(null)
-
-  const handleRecipientChange = useCallback(
-    (index: number, field: keyof Recipient, value: string) => {
-      setRecipients((prev) => {
-        const next = [...prev]
-        next[index] = { ...next[index], [field]: value }
-        return next
-      })
-      setFormError(null)
-    },
-    [],
-  )
-
-  const handleAddRecipient = useCallback(() => {
-    setRecipients((prev) => [...prev, { ...emptyRecipient }])
-  }, [])
-
-  const handleRemoveRecipient = useCallback((index: number) => {
-    setRecipients((prev) => prev.filter((_, i) => i !== index))
-  }, [])
-
-  const validate = useCallback(() => {
-    for (const r of recipients) {
-      if (!r.address || !r.address.startsWith('0x') || r.address.length < 42) {
-        setFormError('Invalid Ethereum address')
-        return false
-      }
-      const amount = Number(r.amount)
-      if (!amount || amount <= 0) {
-        setFormError('Amount must be greater than 0')
-        return false
-      }
-    }
-
-    const totalAmount = recipients.reduce((sum, r) => sum + Number(r.amount), 0)
-
-    if (creditBalance && totalAmount > creditBalance) {
-      setFormError('Total amount exceeds your balance')
-      return false
-    }
-
-    return true
-  }, [recipients, creditBalance])
-
-  const onSubmit = useCallback(async () => {
-    if (!validate()) return
-
-    try {
-      await handleSubmit({
-        recipients: recipients.map((r) => ({
-          address: r.address,
-          amount: Number(r.amount),
-          ...(r.expiration && { expiration: r.expiration }),
-        })),
-      })
-      setRecipients([{ ...emptyRecipient }])
-    } catch (err) {
-      setFormError((err as Error).message)
-    }
-  }, [validate, handleSubmit, recipients])
-
-  const handleModalClose = useCallback(() => {
-    setRecipients([{ ...emptyRecipient }])
-    setFormError(null)
-    handleClose()
-  }, [handleClose])
+  const { fields, append, remove } = fieldArray
 
   return (
     <Modal
       open={isOpen}
-      onClose={handleModalClose}
+      onClose={handleClose}
       closeOnCloseButton={false}
       width="32rem"
       header={
@@ -109,104 +37,55 @@ const CreditTransferModal = () => {
             Send credits to another account. Transfers are processed on the
             Aleph network.
           </p>
-          {creditBalance !== undefined && (
-            <p className="tp-body3 text-base2" tw="mt-2">
-              Available: {formatCredits(creditBalance)}
-            </p>
-          )}
+          <p className="tp-body3 text-base2" tw="mt-2">
+            Available: {formatCredits(balanceDollars * CREDITS_PER_USD)}
+          </p>
         </div>
       }
       content={
-        <div tw="flex flex-col gap-4">
-          {recipients.map((r, index) => (
-            <div
-              key={index}
-              tw="flex flex-col gap-3 pb-4"
-              css={
-                index > 0
-                  ? 'border-top: 1px solid rgba(255,255,255,0.1);padding-top:1rem;'
-                  : ''
-              }
-            >
-              {recipients.length > 1 && (
-                <div tw="flex items-center justify-between">
-                  <span className="tp-body2">Recipient {index + 1}</span>
-                </div>
-              )}
-              <TextInput
-                name={`address-${index}`}
-                label="Recipient Address"
-                placeholder="0x..."
-                value={r.address}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleRecipientChange(index, 'address', e.target.value)
-                }
+        <Form onSubmit={handleSubmit} errors={errors}>
+          <div tw="flex flex-col gap-4 px-4">
+            {fields.map((field, index) => (
+              <RecipientRow
+                key={field.id}
+                index={index}
+                control={control}
+                showRemove={fields.length > 1}
+                onRemove={() => remove(index)}
+                onFillMax={() => handleFillMax(index)}
               />
-              <TextInput
-                name={`amount-${index}`}
-                label="Amount (credits)"
-                placeholder="1000000"
-                type="number"
-                value={r.amount}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleRecipientChange(index, 'amount', e.target.value)
+            ))}
+
+            <div tw="text-center">
+              <Button
+                type="button"
+                color="main0"
+                kind="gradient"
+                variant="secondary"
+                size="md"
+                onClick={() =>
+                  append({
+                    address: '',
+                    amount: '' as unknown as number,
+                    expiration: '',
+                  })
                 }
-              />
-              <TextInput
-                name={`expiration-${index}`}
-                label="Expiration (optional)"
-                type="date"
-                value={r.expiration}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleRecipientChange(index, 'expiration', e.target.value)
-                }
-              />
-              {recipients.length > 1 && (
-                <div tw="mt-4 pt-6 text-right">
-                  <Button
-                    type="button"
-                    kind="functional"
-                    variant="warning"
-                    size="md"
-                    onClick={() => handleRemoveRecipient(index)}
-                  >
-                    Remove
-                  </Button>
-                </div>
-              )}
+              >
+                Add recipient <Icon name="plus-circle" />
+              </Button>
             </div>
-          ))}
 
-          <div tw="text-center">
-            <Button
-              type="button"
-              color="main0"
-              kind="gradient"
-              variant="secondary"
-              size="md"
-              onClick={handleAddRecipient}
-            >
-              Add recipient <Icon name="plus-circle" />
-            </Button>
+            <SpinnerOverlay show={isSubmitLoading} center size="8rem" />
           </div>
-
-          {(formError || error) && (
-            <p className="tp-body2 text-error" tw="mt-2">
-              <Icon name="exclamation-triangle" tw="mr-2" />
-              {formError || error?.message}
-            </p>
-          )}
-
-          <SpinnerOverlay show={loading} center size="8rem" />
-        </div>
+        </Form>
       }
       footer={
         <div tw="flex justify-center">
           <Button
             variant="primary"
             size="md"
-            disabled={loading}
-            onClick={onSubmit}
+            disabled={isSubmitLoading}
+            onClick={handleSubmit}
           >
             Confirm Transfer <Icon name="arrow-right" />
           </Button>
@@ -218,3 +97,99 @@ const CreditTransferModal = () => {
 CreditTransferModal.displayName = 'CreditTransferModal'
 
 export default memo(CreditTransferModal)
+
+// --- Recipient row sub-component ---
+
+type RecipientRowProps = {
+  index: number
+  control: any
+  showRemove: boolean
+  onRemove: () => void
+  onFillMax: () => void
+}
+
+const RecipientRow = memo(
+  ({ index, control, showRemove, onRemove, onFillMax }: RecipientRowProps) => {
+    const addressCtrl = useController({
+      control,
+      name: `recipients.${index}.address`,
+    })
+    const amountCtrl = useController({
+      control,
+      name: `recipients.${index}.amount`,
+    })
+    const expirationCtrl = useController({
+      control,
+      name: `recipients.${index}.expiration`,
+    })
+
+    return (
+      <div
+        tw="flex flex-col gap-3 pb-4"
+        css={
+          showRemove
+            ? 'border-top: 1px solid rgba(255,255,255,0.1);padding-top:1rem;'
+            : ''
+        }
+      >
+        {showRemove && (
+          <div tw="flex items-center justify-between">
+            <span className="tp-body2">Recipient {index + 1}</span>
+          </div>
+        )}
+        <TextInput
+          {...addressCtrl.field}
+          name={`address-${index}`}
+          label="Recipient Address"
+          placeholder="0x..."
+          error={addressCtrl.fieldState.error}
+        />
+        <TextInput
+          {...amountCtrl.field}
+          value={amountCtrl.field.value || ''}
+          name={`amount-${index}`}
+          label="Amount ($)"
+          placeholder="10.50"
+          type="number"
+          step="any"
+          error={amountCtrl.fieldState.error}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const raw = e.target.value
+            amountCtrl.field.onChange(raw === '' ? '' : raw)
+          }}
+          button={
+            <Button
+              type="button"
+              variant="textOnly"
+              size="sm"
+              onClick={onFillMax}
+              tw="mr-2!"
+            >
+              Max
+            </Button>
+          }
+        />
+        <TextInput
+          {...expirationCtrl.field}
+          name={`expiration-${index}`}
+          label="Expiration (optional)"
+          type="date"
+        />
+        {showRemove && (
+          <div tw="mt-4 pt-6 text-right">
+            <Button
+              type="button"
+              kind="functional"
+              variant="warning"
+              size="md"
+              onClick={onRemove}
+            >
+              Remove
+            </Button>
+          </div>
+        )}
+      </div>
+    )
+  },
+)
+RecipientRow.displayName = 'RecipientRow'

--- a/src/components/modals/CreditTransferModal/hook.ts
+++ b/src/components/modals/CreditTransferModal/hook.ts
@@ -1,12 +1,34 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useFieldArray } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useAppState } from '@/contexts/appState'
 import {
   openCreditTransferModal,
   closeCreditTransferModal,
   openTransferStatusModal,
 } from '@/store/ui'
+import { useForm } from '@/hooks/common/useForm'
+import {
+  stepsCatalog,
+  useCheckoutNotification,
+} from '@/hooks/form/useCheckoutNotification'
 import { useCreditTransfer } from '@/hooks/common/useCreditTransfer'
-import { UseCreditTransferModalReturn, CreditTransferFormData } from './types'
+import { useConnection } from '@/hooks/common/useConnection'
+import { CREDITS_PER_USD } from '@/domain/credit'
+import {
+  CreditTransferFormData,
+  creditTransferSchema,
+} from '@/helpers/schemas/credit'
+import {
+  UseCreditTransferModalReturn,
+  UseCreditTransferModalFormReturn,
+} from './types'
+
+const defaultValues = {
+  recipients: [
+    { address: '', amount: '' as unknown as number, expiration: '' },
+  ],
+} as CreditTransferFormData
 
 export function useCreditTransferModal(): UseCreditTransferModalReturn {
   const [state, dispatch] = useAppState()
@@ -24,32 +46,92 @@ export function useCreditTransferModal(): UseCreditTransferModalReturn {
   return { isOpen, handleOpen, handleClose }
 }
 
-export function useCreditTransferForm() {
+export function useCreditTransferModalForm(): UseCreditTransferModalFormReturn {
   const [, dispatch] = useAppState()
-  const { transfer, loading, error } = useCreditTransfer()
+  const { transfer } = useCreditTransfer()
+  const { creditBalance } = useConnection({ triggerOnMount: false })
   const { handleClose } = useCreditTransferModal()
+  const { next, stop } = useCheckoutNotification({})
 
-  const handleSubmit = useCallback(
+  const balanceDollars = useMemo(
+    () => (creditBalance ? creditBalance / CREDITS_PER_USD : 0),
+    [creditBalance],
+  )
+
+  const onSubmit = useCallback(
     async (data: CreditTransferFormData) => {
+      const nSteps = [stepsCatalog['creditTransfer']]
+
+      // Convert $ amounts to credits
       const recipients = data.recipients.map((r) => ({
         address: r.address,
-        amount: r.amount,
+        amount: Math.round(r.amount * CREDITS_PER_USD),
         ...(r.expiration && {
           expiration: new Date(r.expiration).getTime(),
         }),
       }))
 
-      const itemHash = await transfer(recipients)
+      try {
+        await next(nSteps)
+        const itemHash = await transfer(recipients)
 
-      handleClose()
-      dispatch(openTransferStatusModal(itemHash))
+        handleClose()
+        dispatch(openTransferStatusModal(itemHash))
+
+        return itemHash
+      } finally {
+        await stop()
+      }
     },
-    [transfer, handleClose, dispatch],
+    [transfer, handleClose, dispatch, next, stop],
+  )
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    getValues,
+    requestState: { loading: isSubmitLoading },
+  } = useForm({
+    defaultValues,
+    onSubmit,
+    onSuccess: async () => undefined,
+    resolver: zodResolver(creditTransferSchema),
+  })
+
+  const fieldArray = useFieldArray({
+    control,
+    name: 'recipients',
+  })
+
+  const handleFillMax = useCallback(
+    (index: number) => {
+      const currentRecipients = getValues('recipients')
+      const othersTotal = currentRecipients.reduce(
+        (sum, r, i) => (i === index ? sum : sum + (Number(r.amount) || 0)),
+        0,
+      )
+      // Floor to 6 decimals to ensure integer credits after * CREDITS_PER_USD
+      const maxForThis =
+        Math.floor(
+          Math.max(0, balanceDollars - othersTotal) * CREDITS_PER_USD,
+        ) / CREDITS_PER_USD
+
+      setValue(`recipients.${index}.amount`, maxForThis, {
+        shouldValidate: true,
+      })
+    },
+    [balanceDollars, getValues, setValue],
   )
 
   return {
+    control,
     handleSubmit,
-    loading,
-    error,
+    errors,
+    isSubmitLoading,
+    fieldArray,
+    balanceDollars,
+    handleFillMax,
   }
 }

--- a/src/components/modals/CreditTransferModal/hook.ts
+++ b/src/components/modals/CreditTransferModal/hook.ts
@@ -1,0 +1,55 @@
+import { useCallback } from 'react'
+import { useAppState } from '@/contexts/appState'
+import {
+  openCreditTransferModal,
+  closeCreditTransferModal,
+  openTransferStatusModal,
+} from '@/store/ui'
+import { useCreditTransfer } from '@/hooks/common/useCreditTransfer'
+import { UseCreditTransferModalReturn, CreditTransferFormData } from './types'
+
+export function useCreditTransferModal(): UseCreditTransferModalReturn {
+  const [state, dispatch] = useAppState()
+
+  const isOpen = state.ui.isCreditTransferModalOpen
+
+  const handleOpen = useCallback(() => {
+    dispatch(openCreditTransferModal())
+  }, [dispatch])
+
+  const handleClose = useCallback(() => {
+    dispatch(closeCreditTransferModal())
+  }, [dispatch])
+
+  return { isOpen, handleOpen, handleClose }
+}
+
+export function useCreditTransferForm() {
+  const [, dispatch] = useAppState()
+  const { transfer, loading, error } = useCreditTransfer()
+  const { handleClose } = useCreditTransferModal()
+
+  const handleSubmit = useCallback(
+    async (data: CreditTransferFormData) => {
+      const recipients = data.recipients.map((r) => ({
+        address: r.address,
+        amount: r.amount,
+        ...(r.expiration && {
+          expiration: new Date(r.expiration).getTime(),
+        }),
+      }))
+
+      const itemHash = await transfer(recipients)
+
+      handleClose()
+      dispatch(openTransferStatusModal(itemHash))
+    },
+    [transfer, handleClose, dispatch],
+  )
+
+  return {
+    handleSubmit,
+    loading,
+    error,
+  }
+}

--- a/src/components/modals/CreditTransferModal/index.ts
+++ b/src/components/modals/CreditTransferModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './cmp'
+export { useCreditTransferModal } from './hook'

--- a/src/components/modals/CreditTransferModal/types.ts
+++ b/src/components/modals/CreditTransferModal/types.ts
@@ -1,13 +1,19 @@
+import { UseFormReturn } from '@/hooks/common/useForm'
+import { CreditTransferFormData } from '@/helpers/schemas/credit'
+import { UseFieldArrayReturn } from 'react-hook-form'
+
 export type UseCreditTransferModalReturn = {
   isOpen: boolean
   handleOpen: () => void
   handleClose: () => void
 }
 
-export type CreditTransferFormData = {
-  recipients: {
-    address: string
-    amount: number
-    expiration?: string
-  }[]
+export type UseCreditTransferModalFormReturn = {
+  control: UseFormReturn<CreditTransferFormData, string>['control']
+  handleSubmit: UseFormReturn<CreditTransferFormData, string>['handleSubmit']
+  errors: UseFormReturn<CreditTransferFormData, string>['formState']['errors']
+  isSubmitLoading: boolean
+  fieldArray: UseFieldArrayReturn<CreditTransferFormData, 'recipients'>
+  balanceDollars: number
+  handleFillMax: (index: number) => void
 }

--- a/src/components/modals/CreditTransferModal/types.ts
+++ b/src/components/modals/CreditTransferModal/types.ts
@@ -1,0 +1,13 @@
+export type UseCreditTransferModalReturn = {
+  isOpen: boolean
+  handleOpen: () => void
+  handleClose: () => void
+}
+
+export type CreditTransferFormData = {
+  recipients: {
+    address: string
+    amount: number
+    expiration?: string
+  }[]
+}

--- a/src/components/modals/TransferStatusModal/cmp.tsx
+++ b/src/components/modals/TransferStatusModal/cmp.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useEffect, useMemo } from 'react'
 import 'twin.macro'
 import { Button, Icon, Modal, Spinner, TextGradient } from '@aleph-front/core'
 import { useAppState } from '@/contexts/appState'
-import { closeTransferStatusModal } from '@/store/ui'
+import { closeTransferStatusModal, triggerCreditDataRefresh } from '@/store/ui'
 import {
   useTransferStatus,
   TransferStatus,
@@ -14,6 +14,7 @@ import {
   StyledProgressStepIcon,
   StyledProgressContent,
   StyledProgressTitle,
+  StyledProgressDescription,
 } from '@/components/modals/PaymentStatusModal/styles'
 
 const stepDefinitions = [
@@ -22,12 +23,15 @@ const stepDefinitions = [
     pendingLabel: 'Submit transfer',
     currentLabel: 'Submitting transfer',
     completedLabel: 'Transfer submitted',
+    description:
+      'Signing and sending the transfer message to the Aleph network.',
   },
   {
     key: 'processed',
     pendingLabel: 'Process transfer',
     currentLabel: 'Processing transfer',
     completedLabel: 'Transfer processed',
+    description: 'The network is verifying and processing the credit transfer.',
   },
 ]
 
@@ -57,6 +61,7 @@ const getProgressSteps = (status: TransferStatus) => {
 const TransferStatusModal = () => {
   const [state, dispatch] = useAppState()
   const { isTransferStatusModalOpen: isOpen, transferStatusItemHash } = state.ui
+  const accountAddress = state.connection.account?.address
 
   const { status, startPolling, stopPolling } = useTransferStatus()
 
@@ -68,6 +73,13 @@ const TransferStatusModal = () => {
       stopPolling()
     }
   }, [isOpen, transferStatusItemHash, startPolling, stopPolling])
+
+  // Refresh all credit data when transfer is processed
+  useEffect(() => {
+    if (status === 'processed') {
+      dispatch(triggerCreditDataRefresh())
+    }
+  }, [status, dispatch])
 
   const handleClose = useCallback(() => {
     stopPolling()
@@ -145,28 +157,27 @@ const TransferStatusModal = () => {
                         ? step.currentLabel
                         : step.pendingLabel}
                   </StyledProgressTitle>
+                  {step.key === 'sent' && transferStatusItemHash && (
+                    <StyledProgressDescription>
+                      <a
+                        href={`https://explorer.aleph.im/address/ETH/${accountAddress}/message/POST/${transferStatusItemHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        tw="inline-flex items-center gap-2"
+                      >
+                        {formatHash(transferStatusItemHash)}
+                        <Icon
+                          name="external-link-square-alt"
+                          size="12px"
+                          color="purple4"
+                        />
+                      </a>
+                    </StyledProgressDescription>
+                  )}
                 </StyledProgressContent>
               </StyledProgressStep>
             ))}
           </StyledProgressContainer>
-          {transferStatusItemHash && (
-            <div tw="mt-4">
-              <a
-                href={`https://explorer.aleph.im/address/ETH/${transferStatusItemHash}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                tw="flex items-center gap-2"
-                className="text-main0 tp-body3"
-              >
-                {formatHash(transferStatusItemHash)}
-                <Icon
-                  name="external-link-square-alt"
-                  size="12px"
-                  color="purple4"
-                />
-              </a>
-            </div>
-          )}
         </>
       }
       footer={

--- a/src/components/modals/TransferStatusModal/cmp.tsx
+++ b/src/components/modals/TransferStatusModal/cmp.tsx
@@ -1,0 +1,184 @@
+import React, { memo, useCallback, useEffect, useMemo } from 'react'
+import 'twin.macro'
+import { Button, Icon, Modal, Spinner, TextGradient } from '@aleph-front/core'
+import { useAppState } from '@/contexts/appState'
+import { closeTransferStatusModal } from '@/store/ui'
+import {
+  useTransferStatus,
+  TransferStatus,
+} from '@/hooks/common/useTransferStatus'
+import BorderBox from '@/components/common/BorderBox'
+import {
+  StyledProgressContainer,
+  StyledProgressStep,
+  StyledProgressStepIcon,
+  StyledProgressContent,
+  StyledProgressTitle,
+} from '@/components/modals/PaymentStatusModal/styles'
+
+const stepDefinitions = [
+  {
+    key: 'sent',
+    pendingLabel: 'Submit transfer',
+    currentLabel: 'Submitting transfer',
+    completedLabel: 'Transfer submitted',
+  },
+  {
+    key: 'processed',
+    pendingLabel: 'Process transfer',
+    currentLabel: 'Processing transfer',
+    completedLabel: 'Transfer processed',
+  },
+]
+
+const getProgressSteps = (status: TransferStatus) => {
+  let completedCount = 0
+  switch (status) {
+    case 'processed':
+      completedCount = 2
+      break
+    case 'pending':
+      completedCount = 1
+      break
+    default:
+      completedCount = 0
+      break
+  }
+
+  const isFinal = status === 'processed' || status === 'rejected'
+
+  return stepDefinitions.map((step, index) => ({
+    ...step,
+    completed: index < completedCount,
+    current: !isFinal && index === completedCount,
+  }))
+}
+
+const TransferStatusModal = () => {
+  const [state, dispatch] = useAppState()
+  const { isTransferStatusModalOpen: isOpen, transferStatusItemHash } = state.ui
+
+  const { status, startPolling, stopPolling } = useTransferStatus()
+
+  useEffect(() => {
+    if (isOpen && transferStatusItemHash) {
+      startPolling(transferStatusItemHash)
+    }
+    return () => {
+      stopPolling()
+    }
+  }, [isOpen, transferStatusItemHash, startPolling, stopPolling])
+
+  const handleClose = useCallback(() => {
+    stopPolling()
+    dispatch(closeTransferStatusModal())
+  }, [dispatch, stopPolling])
+
+  const progressSteps = useMemo(() => getProgressSteps(status), [status])
+
+  const isCompleted = status === 'processed'
+  const isError = status === 'rejected'
+
+  const formatHash = (hash?: string) => {
+    if (!hash) return ''
+    return `${hash.slice(0, 16)}...${hash.slice(-8)}`
+  }
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={handleClose}
+      width="36rem"
+      header={
+        <div>
+          <TextGradient type="h6" forwardedAs="h2" tw="mb-2">
+            {isCompleted
+              ? 'Transfer complete'
+              : isError
+                ? 'Transfer failed'
+                : 'Transfer in progress'}
+          </TextGradient>
+          <p tw="m-0">
+            {isCompleted
+              ? 'Credits have been successfully transferred.'
+              : isError
+                ? 'The transfer was rejected by the network.'
+                : 'Your transfer is being processed on the network.'}
+          </p>
+        </div>
+      }
+      content={
+        <>
+          {isCompleted && (
+            <BorderBox $color="main0" tw="my-4" className="tp-body1">
+              Credits have been successfully transferred to the recipient
+              account.
+            </BorderBox>
+          )}
+          {isError && (
+            <BorderBox $color="error" tw="my-4" className="tp-body1">
+              The transfer was rejected. Please check the recipient address and
+              your balance, then try again.
+            </BorderBox>
+          )}
+          <StyledProgressContainer>
+            {progressSteps.map((step) => (
+              <StyledProgressStep key={step.key}>
+                {step.current ? (
+                  <Spinner size="3rem" color="main0" tw="-m-4" />
+                ) : (
+                  <StyledProgressStepIcon
+                    name={step.key}
+                    value={step.key}
+                    checked={step.completed}
+                    disabled={!step.completed}
+                    size="xs"
+                  />
+                )}
+                <StyledProgressContent>
+                  <StyledProgressTitle
+                    completed={step.completed || step.current}
+                  >
+                    {step.completed
+                      ? step.completedLabel
+                      : step.current
+                        ? step.currentLabel
+                        : step.pendingLabel}
+                  </StyledProgressTitle>
+                </StyledProgressContent>
+              </StyledProgressStep>
+            ))}
+          </StyledProgressContainer>
+          {transferStatusItemHash && (
+            <div tw="mt-4">
+              <a
+                href={`https://explorer.aleph.im/address/ETH/${transferStatusItemHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                tw="flex items-center gap-2"
+                className="text-main0 tp-body3"
+              >
+                {formatHash(transferStatusItemHash)}
+                <Icon
+                  name="external-link-square-alt"
+                  size="12px"
+                  color="purple4"
+                />
+              </a>
+            </div>
+          )}
+        </>
+      }
+      footer={
+        <div tw="flex justify-end">
+          <Button variant="primary" size="md" onClick={handleClose}>
+            Close
+          </Button>
+        </div>
+      }
+    />
+  )
+}
+TransferStatusModal.displayName = 'TransferStatusModal'
+
+export default memo(TransferStatusModal)

--- a/src/components/modals/TransferStatusModal/index.ts
+++ b/src/components/modals/TransferStatusModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/modals/TransferStatusModal/types.ts
+++ b/src/components/modals/TransferStatusModal/types.ts
@@ -1,0 +1,10 @@
+export type TransferStatusModalProps = Record<string, never>
+
+export type TransferStatusStep = {
+  key: string
+  pendingLabel: string
+  currentLabel: string
+  completedLabel: string
+  completed: boolean
+  current: boolean
+}

--- a/src/components/pages/console/CreditsDashboardPage/CreditCharts/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/CreditCharts/cmp.tsx
@@ -1,0 +1,274 @@
+import React, { memo, useState } from 'react'
+import 'twin.macro'
+import { useTheme } from 'styled-components'
+import {
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import { ColorDot, NoisyContainer, TextGradient } from '@aleph-front/core'
+import { SVGGradients } from '@/components/common/charts'
+import ToggleDashboard from '@/components/common/ToggleDashboard'
+import Skeleton from '@/components/common/Skeleton'
+import { SectionTitle } from '@/components/common/CompositeTitle'
+import { useCreditCharts } from './hook'
+import { CreditChartsProps } from './types'
+import { formatCredits } from '@/helpers/utils'
+
+const CreditCharts = ({
+  isConnected,
+  costsResources,
+  costsLoading,
+}: CreditChartsProps) => {
+  const theme = useTheme()
+  const [chartsOpen, setChartsOpen] = useState(false)
+
+  const {
+    serviceTypePieData,
+    expenseSharePieData,
+    dailyChartData,
+    chartLoading,
+  } = useCreditCharts(costsResources)
+
+  const disabledColor = theme.color.disabled2
+  const isLoading = costsLoading || chartLoading
+
+  return (
+    <section tw="px-0 pb-6 pt-6 lg:pb-5">
+      <SectionTitle>Charts</SectionTitle>
+      <ToggleDashboard
+        open={chartsOpen}
+        setOpen={setChartsOpen}
+        toggleButton={{
+          children: <>Show charts</>,
+          disabled: !isConnected,
+        }}
+      >
+        {isLoading ? (
+          <div tw="flex gap-6 flex-wrap">
+            <Skeleton width="100%" height="16rem" />
+          </div>
+        ) : (
+          <div tw="flex gap-6 flex-wrap">
+            {/* Pie Charts */}
+            <NoisyContainer tw="flex-1 min-w-[20rem]">
+              <div tw="flex gap-6 flex-wrap justify-around">
+                {/* Service type distribution */}
+                <div tw="flex flex-col items-center">
+                  <TextGradient
+                    forwardedAs="h3"
+                    type="info"
+                    color="main0"
+                    tw="m-0 mb-2"
+                  >
+                    By Service Type
+                  </TextGradient>
+                  {serviceTypePieData.length > 0 ? (
+                    <>
+                      <PieChart width={120} height={120}>
+                        <defs>
+                          <SVGGradients data={serviceTypePieData} />
+                        </defs>
+                        <Pie
+                          data={[{ v: 1 }]}
+                          dataKey="v"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                          isAnimationActive={false}
+                          fill={disabledColor}
+                        />
+                        <Pie
+                          data={serviceTypePieData}
+                          dataKey="value"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                        >
+                          {serviceTypePieData.map((entry) => {
+                            const color = `gr-${entry.gradient}`
+                            const fill = entry.gradient
+                              ? `url(#${color})`
+                              : entry.color
+                                ? theme.color[entry.color] || entry.color
+                                : undefined
+                            return <Cell key={entry.label} fill={fill} />
+                          })}
+                        </Pie>
+                      </PieChart>
+                      <div tw="mt-2 flex flex-col gap-2">
+                        {serviceTypePieData.map((entry) => (
+                          <div key={entry.label} tw="flex items-center gap-2">
+                            <ColorDot
+                              $gradient={entry.gradient}
+                              $size="0.75rem"
+                            />
+                            <span className="tp-body3">
+                              {entry.value} {entry.label}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-base2 tp-body3">No services</p>
+                  )}
+                </div>
+
+                {/* Expense share */}
+                <div tw="flex flex-col items-center">
+                  <TextGradient
+                    forwardedAs="h3"
+                    type="info"
+                    color="main0"
+                    tw="m-0 mb-2"
+                  >
+                    Expense Share
+                  </TextGradient>
+                  {expenseSharePieData.length > 0 ? (
+                    <>
+                      <PieChart width={120} height={120}>
+                        <defs>
+                          <SVGGradients data={expenseSharePieData} />
+                        </defs>
+                        <Pie
+                          data={[{ v: 1 }]}
+                          dataKey="v"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                          isAnimationActive={false}
+                          fill={disabledColor}
+                        />
+                        <Pie
+                          data={expenseSharePieData}
+                          dataKey="value"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                        >
+                          {expenseSharePieData.map((entry) => {
+                            const color = `gr-${entry.gradient}`
+                            const fill = entry.gradient
+                              ? `url(#${color})`
+                              : entry.color
+                                ? theme.color[entry.color] || entry.color
+                                : undefined
+                            return <Cell key={entry.label} fill={fill} />
+                          })}
+                        </Pie>
+                      </PieChart>
+                      <div tw="mt-2 flex flex-col gap-2">
+                        {expenseSharePieData.map((entry) => (
+                          <div key={entry.label} tw="flex items-center gap-2">
+                            <ColorDot
+                              $gradient={entry.gradient}
+                              $size="0.75rem"
+                            />
+                            <span className="tp-body3">{entry.label}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-base2 tp-body3">No expenses</p>
+                  )}
+                </div>
+              </div>
+            </NoisyContainer>
+
+            {/* Line Chart */}
+            <NoisyContainer tw="flex-[2] min-w-[20rem]">
+              <TextGradient
+                forwardedAs="h3"
+                type="info"
+                color="main0"
+                tw="m-0 mb-4"
+              >
+                30-Day Activity
+              </TextGradient>
+              {dailyChartData.length > 0 ? (
+                <ResponsiveContainer width="100%" height={250}>
+                  <LineChart data={dailyChartData}>
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(v: string) => v.slice(5)}
+                      stroke={theme.color.base2}
+                    />
+                    <YAxis
+                      yAxisId="expenses"
+                      orientation="left"
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(v: number) => formatCredits(v, 0)}
+                      stroke={theme.color.base2}
+                    />
+                    <YAxis
+                      yAxisId="balance"
+                      orientation="right"
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(v: number) => formatCredits(v, 0)}
+                      stroke={theme.color.base2}
+                    />
+                    <Tooltip
+                      formatter={(value: number, name: string) => [
+                        formatCredits(value),
+                        name,
+                      ]}
+                      labelFormatter={(label: string) => `Date: ${label}`}
+                      contentStyle={{
+                        background: theme.color.base0,
+                        border: `1px solid ${theme.color.base2}`,
+                      }}
+                    />
+                    <Legend />
+                    <Line
+                      yAxisId="expenses"
+                      type="monotone"
+                      dataKey="expenses"
+                      name="Daily Expenses"
+                      stroke={theme.color.main0}
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                    <Line
+                      yAxisId="balance"
+                      type="monotone"
+                      dataKey="balance"
+                      name="Balance"
+                      stroke={theme.color.info}
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              ) : (
+                <p className="text-base2 tp-body3">
+                  No activity in the last 30 days
+                </p>
+              )}
+            </NoisyContainer>
+          </div>
+        )}
+      </ToggleDashboard>
+    </section>
+  )
+}
+CreditCharts.displayName = 'CreditCharts'
+
+export default memo(CreditCharts)

--- a/src/components/pages/console/CreditsDashboardPage/CreditCharts/hook.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditCharts/hook.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+import { useAccountEntities } from '@/hooks/common/useAccountEntities'
+import { CostsResource } from '@/hooks/common/useServiceCosts'
+import { CreditHistoryEntry } from '@/hooks/common/useCreditHistory'
+import { getApiServer } from '@/helpers/server'
+import { DailyChartData } from './types'
+
+const CHART_GRADIENT_KEYS = ['main0', 'main1', 'info', 'success', 'warning']
+
+export type PieChartEntry = {
+  label: string
+  value: number
+  gradient?: string
+  color?: string
+}
+
+export type UseCreditChartsReturn = {
+  serviceTypePieData: PieChartEntry[]
+  expenseSharePieData: PieChartEntry[]
+  dailyChartData: DailyChartData[]
+  chartLoading: boolean
+}
+
+export function useCreditCharts(
+  costsResources: CostsResource[],
+): UseCreditChartsReturn {
+  const [state] = useAppState()
+  const { account, creditBalance } = state.connection
+  const { instances, gpuInstances, confidentials, volumes, websites } =
+    useAccountEntities()
+
+  const [dailyChartData, setDailyChartData] = useState<DailyChartData[]>([])
+  const [chartLoading, setChartLoading] = useState(false)
+
+  // Build a map from item_hash to entity type
+  const entityTypeMap = useMemo(() => {
+    const map = new Map<string, string>()
+    instances.forEach((e) => map.set(e.id, 'Instance'))
+    gpuInstances.forEach((e) => map.set(e.id, 'GPU'))
+    confidentials.forEach((e) => map.set(e.id, 'Confidential'))
+    volumes.forEach((e) => map.set(e.id, 'Volume'))
+    websites.forEach((e) => map.set(e.id, 'Website'))
+    return map
+  }, [instances, gpuInstances, confidentials, volumes, websites])
+
+  // Pie chart: service type distribution
+  const serviceTypePieData = useMemo(() => {
+    const typeCounts: Record<string, number> = {}
+
+    costsResources.forEach((r) => {
+      const type = entityTypeMap.get(r.item_hash) || 'Other'
+      typeCounts[type] = (typeCounts[type] || 0) + 1
+    })
+
+    return Object.entries(typeCounts).map(([label, value], i) => ({
+      label,
+      value,
+      gradient: CHART_GRADIENT_KEYS[i % CHART_GRADIENT_KEYS.length],
+    }))
+  }, [costsResources, entityTypeMap])
+
+  // Pie chart: expense share by resource
+  const expenseSharePieData = useMemo(() => {
+    return costsResources
+      .filter((r) => r.consumed_credits > 0)
+      .sort((a, b) => b.consumed_credits - a.consumed_credits)
+      .slice(0, 8)
+      .map((r, i) => {
+        const type = entityTypeMap.get(r.item_hash) || 'Unknown'
+        const shortHash = r.item_hash.slice(0, 8)
+        return {
+          label: `${type} (${shortHash})`,
+          value: r.consumed_credits,
+          gradient: CHART_GRADIENT_KEYS[i % CHART_GRADIENT_KEYS.length],
+        }
+      })
+  }, [costsResources, entityTypeMap])
+
+  // 30-day line chart: fetch and aggregate credit history
+  const fetchDailyData = useCallback(async () => {
+    if (!account?.address) return
+
+    setChartLoading(true)
+    try {
+      const apiServer = getApiServer()
+      const thirtyDaysAgo = new Date()
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+      const allEntries: CreditHistoryEntry[] = []
+      let page = 1
+      let hasMore = true
+
+      while (hasMore) {
+        const params = new URLSearchParams({
+          pagination: '200',
+          page: String(page),
+        })
+
+        const response = await fetch(
+          `${apiServer}/api/v0/addresses/${account.address}/credit_history?${params}`,
+        )
+
+        if (!response.ok) break
+
+        const data = await response.json()
+        const entries: CreditHistoryEntry[] = data.credit_history || []
+
+        if (entries.length === 0) {
+          hasMore = false
+          break
+        }
+
+        // Check if we've gone past 30 days
+        const oldestEntry = entries[entries.length - 1]
+        const oldestDate = new Date(oldestEntry.message_timestamp)
+
+        allEntries.push(
+          ...entries.filter(
+            (e) => new Date(e.message_timestamp) >= thirtyDaysAgo,
+          ),
+        )
+
+        if (oldestDate < thirtyDaysAgo) {
+          hasMore = false
+        } else {
+          page++
+        }
+      }
+
+      // Aggregate by day
+      const dailyMap = new Map<string, { expenses: number; income: number }>()
+
+      // Initialize all 30 days
+      for (let i = 29; i >= 0; i--) {
+        const d = new Date()
+        d.setDate(d.getDate() - i)
+        const key = d.toISOString().split('T')[0]
+        dailyMap.set(key, { expenses: 0, income: 0 })
+      }
+
+      allEntries.forEach((entry) => {
+        const dateKey = entry.message_timestamp.split('T')[0]
+        const existing = dailyMap.get(dateKey)
+        if (existing) {
+          if (entry.amount < 0) {
+            existing.expenses += Math.abs(entry.amount)
+          } else {
+            existing.income += entry.amount
+          }
+        }
+      })
+
+      // Build chart data with running balance
+      const currentBalance = creditBalance || 0
+      const chartEntries: DailyChartData[] = []
+      const sortedDays = Array.from(dailyMap.entries()).sort(([a], [b]) =>
+        a.localeCompare(b),
+      )
+
+      // Calculate balance for each day by working backwards
+      let runningBalance = currentBalance
+      const balanceByDay = new Map<string, number>()
+
+      for (let i = sortedDays.length - 1; i >= 0; i--) {
+        const [dateKey, data] = sortedDays[i]
+        balanceByDay.set(dateKey, runningBalance)
+        runningBalance = runningBalance + data.expenses - data.income
+      }
+
+      sortedDays.forEach(([dateKey, data]) => {
+        chartEntries.push({
+          date: dateKey,
+          expenses: data.expenses,
+          balance: balanceByDay.get(dateKey) || 0,
+        })
+      })
+
+      setDailyChartData(chartEntries)
+    } catch (err) {
+      console.error('Error fetching chart data:', err)
+    } finally {
+      setChartLoading(false)
+    }
+  }, [account?.address, creditBalance])
+
+  useEffect(() => {
+    fetchDailyData()
+  }, [fetchDailyData])
+
+  return {
+    serviceTypePieData,
+    expenseSharePieData,
+    dailyChartData,
+    chartLoading,
+  }
+}

--- a/src/components/pages/console/CreditsDashboardPage/CreditCharts/hook.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditCharts/hook.ts
@@ -4,12 +4,14 @@ import { useAccountEntities } from '@/hooks/common/useAccountEntities'
 import { CostsResource } from '@/hooks/common/useServiceCosts'
 import { CreditHistoryEntry } from '@/hooks/common/useCreditHistory'
 import { getApiServer } from '@/helpers/server'
+import { formatCredits } from '@/helpers/utils'
 import { DailyChartData } from './types'
 
 const CHART_GRADIENT_KEYS = ['main0', 'main1', 'info', 'success', 'warning']
 
 export type PieChartEntry = {
   label: string
+  displayLabel?: string
   value: number
   gradient?: string
   color?: string
@@ -60,18 +62,30 @@ export function useCreditCharts(
     }))
   }, [costsResources, entityTypeMap])
 
-  // Pie chart: expense share by resource
+  // Pie chart: expense share aggregated by resource type
+  // Uses daily cost rate (credits/second * 86400) for all resources consistently
   const expenseSharePieData = useMemo(() => {
-    return costsResources
-      .filter((r) => r.consumed_credits > 0)
-      .sort((a, b) => b.consumed_credits - a.consumed_credits)
-      .slice(0, 8)
-      .map((r, i) => {
-        const type = entityTypeMap.get(r.item_hash) || 'Unknown'
-        const shortHash = r.item_hash.slice(0, 8)
+    const typeCostPerDay: Record<string, number> = {}
+
+    costsResources.forEach((r) => {
+      const costPerDay = parseFloat(r.cost_credit) * 3600 * 24
+      if (costPerDay <= 0) return
+
+      const type = entityTypeMap.get(r.item_hash) || 'Other'
+      typeCostPerDay[type] = (typeCostPerDay[type] || 0) + costPerDay
+    })
+
+    const total = Object.values(typeCostPerDay).reduce((s, v) => s + v, 0)
+    if (total <= 0) return []
+
+    return Object.entries(typeCostPerDay)
+      .sort(([, a], [, b]) => b - a)
+      .map(([type, dailyCost], i) => {
+        const pct = ((dailyCost / total) * 100).toFixed(1)
         return {
-          label: `${type} (${shortHash})`,
-          value: r.consumed_credits,
+          label: type,
+          displayLabel: `${type} - ${formatCredits(dailyCost)}/day (${pct}%)`,
+          value: dailyCost,
           gradient: CHART_GRADIENT_KEYS[i % CHART_GRADIENT_KEYS.length],
         }
       })

--- a/src/components/pages/console/CreditsDashboardPage/CreditCharts/index.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditCharts/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/console/CreditsDashboardPage/CreditCharts/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditCharts/types.ts
@@ -1,0 +1,13 @@
+import { CostsResource } from '@/hooks/common/useServiceCosts'
+
+export type CreditChartsProps = {
+  isConnected: boolean
+  costsResources: CostsResource[]
+  costsLoading: boolean
+}
+
+export type DailyChartData = {
+  date: string
+  expenses: number
+  balance: number
+}

--- a/src/components/pages/console/CreditsDashboardPage/CreditHistory/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/CreditHistory/cmp.tsx
@@ -13,24 +13,16 @@ import {
 import { StyledTable } from '@/components/common/EntityTable/styles'
 import ToggleDashboard from '@/components/common/ToggleDashboard'
 import { SectionTitle } from '@/components/common/CompositeTitle'
-import { useCreditHistory } from '@/hooks/common/useCreditHistory'
+import {
+  useCreditHistory,
+  CreditHistoryEntry,
+} from '@/hooks/common/useCreditHistory'
+import { ALEPH_CREDIT_SENDER } from '@/domain/credit'
 import { formatCredits, getDate } from '@/helpers/utils'
 import { StyledSectionHeader, StyledScrollableTableContainer } from '../styles'
 import { CreditHistoryProps } from './types'
 
-const PAYMENT_METHOD_LABELS: Record<string, string> = {
-  credit_expense: 'Expense',
-  token_transfer: 'Purchase',
-  credit_transfer: 'Transfer',
-}
-
-const PAYMENT_METHOD_COLORS: Record<string, string> = {
-  credit_expense: 'error',
-  token_transfer: 'success',
-  credit_transfer: 'info',
-}
-
-type TabId = 'all' | 'credit_expense' | 'token_transfer' | 'credit_transfer'
+type TabId = 'all' | 'credit_transfer' | 'credit_expense' | 'token_transfer'
 
 const EmptyTablePlaceholder = ({
   message,
@@ -50,16 +42,327 @@ const EmptyTablePlaceholder = ({
   </NoisyContainer>
 )
 
+const ellipseHash = (hash: string | null | undefined) => {
+  if (!hash || hash === 'None') return '-'
+  return `${hash.slice(0, 6)}...${hash.slice(-4)}`
+}
+
+// Proper Aleph Explorer URL: /address/{chain}/{sender}/message/{type}/{hash}
+const alephExplorerUrl = (hash: string, sender: string, msgType = 'POST') =>
+  `https://explorer.aleph.im/address/ETH/${sender}/message/${msgType}/${hash}`
+
+const HashLink = ({
+  hash,
+  href,
+}: {
+  hash: string | null | undefined
+  href?: string
+}) => {
+  if (!hash || hash === 'None') return <span>-</span>
+  const url = href || '#'
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      tw="flex items-center gap-1"
+      className="text-main0"
+    >
+      {ellipseHash(hash)}
+      <Icon name="external-link-square-alt" size="10px" />
+    </a>
+  )
+}
+
+const EtherscanLink = ({ hash }: { hash: string | null | undefined }) => {
+  if (!hash || hash === 'None') return <span>-</span>
+  return <HashLink hash={hash} href={`https://etherscan.io/tx/${hash}`} />
+}
+
+const AddressLink = ({ address }: { address: string | null | undefined }) => {
+  if (!address || address === 'None') return <span>-</span>
+  return (
+    <HashLink
+      hash={address}
+      href={`https://explorer.aleph.im/address/ETH/${address}`}
+    />
+  )
+}
+
+const AmountCell = ({ amount }: { amount: number }) => (
+  <span style={{ color: amount < 0 ? '#ef4444' : '#22c55e' }}>
+    {formatCredits(amount)}
+  </span>
+)
+
+// --- Column definitions per tab ---
+
+const allColumns = () => [
+  {
+    label: 'TYPE',
+    align: 'left' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) => {
+      const labels: Record<string, string> = {
+        credit_expense: 'Expense',
+        token_transfer: 'Purchase',
+        credit_transfer: 'Transfer',
+      }
+      const colors: Record<string, string> = {
+        credit_expense: 'error',
+        token_transfer: 'success',
+        credit_transfer: 'info',
+      }
+      return (
+        <span tw="flex items-center gap-1.5">
+          <Icon
+            name="circle"
+            gradient={colors[row.payment_method] || 'base2'}
+            size="8px"
+          />
+          {labels[row.payment_method] || row.payment_method}
+        </span>
+      )
+    },
+  },
+  {
+    label: 'AMOUNT',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) => <AmountCell amount={row.amount} />,
+  },
+  {
+    label: 'DATE',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) =>
+      getDate(new Date(row.message_timestamp).getTime() / 1000),
+  },
+  {
+    label: '',
+    align: 'left' as const,
+    width: '100%',
+    render: () => null,
+  },
+]
+
+// Expenses:
+// For VMs: origin = resource (INSTANCE msg), tx_hash = CRN node hash
+// For volumes: origin_ref = resource (STORE msg), no CRN
+const expenseColumns = (
+  accountAddress?: string,
+  knownCrnHashes?: Set<string>,
+) => [
+  {
+    label: 'AMOUNT',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) => <AmountCell amount={row.amount} />,
+  },
+  {
+    label: 'RESOURCE',
+    align: 'left' as const,
+    render: (row: CreditHistoryEntry) => {
+      const isVolume = !row.tx_hash || row.tx_hash === 'None'
+      if (isVolume) {
+        return row.origin_ref && row.origin_ref !== 'None' ? (
+          <HashLink
+            hash={row.origin_ref}
+            href={alephExplorerUrl(
+              row.origin_ref,
+              accountAddress || '',
+              'STORE',
+            )}
+          />
+        ) : (
+          <span>-</span>
+        )
+      }
+      return row.origin && row.origin !== 'None' ? (
+        <HashLink
+          hash={row.origin}
+          href={alephExplorerUrl(row.origin, accountAddress || '', 'INSTANCE')}
+        />
+      ) : (
+        <span>-</span>
+      )
+    },
+  },
+  {
+    label: 'CRN NODE',
+    align: 'left' as const,
+    render: (row: CreditHistoryEntry) => {
+      const isVolume = !row.tx_hash || row.tx_hash === 'None'
+      if (isVolume) return <span>-</span>
+      if (!row.tx_hash || row.tx_hash === 'None') return <span>-</span>
+
+      // If the CRN is in the app state, link in-app
+      const isKnown = knownCrnHashes?.has(row.tx_hash)
+      if (isKnown) {
+        return (
+          <a
+            href={`/account/earn/crn/${row.tx_hash}`}
+            tw="flex items-center gap-1"
+            className="text-main0"
+          >
+            {ellipseHash(row.tx_hash)}
+            <Icon name="angle-right" size="10px" />
+          </a>
+        )
+      }
+
+      // Otherwise link to explorer
+      return (
+        <HashLink
+          hash={row.tx_hash}
+          href={`https://explorer.aleph.im/address/ETH/${row.tx_hash}`}
+        />
+      )
+    },
+  },
+  {
+    label: 'DATE',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) =>
+      getDate(new Date(row.message_timestamp).getTime() / 1000),
+  },
+  {
+    label: '',
+    align: 'left' as const,
+    width: '100%',
+    render: () => null,
+  },
+]
+
+const transferColumns = (accountAddress?: string) => [
+  {
+    label: 'AMOUNT',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) => <AmountCell amount={row.amount} />,
+  },
+  {
+    label: 'SENDER',
+    align: 'left' as const,
+    render: (row: CreditHistoryEntry) => {
+      const sender = row.amount >= 0 ? row.origin : accountAddress || 'You'
+      return sender === accountAddress ? (
+        <span className="text-base2">You</span>
+      ) : (
+        <AddressLink address={sender} />
+      )
+    },
+  },
+  {
+    label: 'RECEIVER',
+    align: 'left' as const,
+    render: (row: CreditHistoryEntry) => {
+      const receiver = row.amount < 0 ? row.origin : accountAddress || 'You'
+      return receiver === accountAddress ? (
+        <span className="text-base2">You</span>
+      ) : (
+        <AddressLink address={receiver} />
+      )
+    },
+  },
+  {
+    label: 'EXPIRATION',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) =>
+      row.expiration_date
+        ? getDate(new Date(row.expiration_date).getTime() / 1000)
+        : 'None',
+  },
+  {
+    label: 'DATE',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) =>
+      getDate(new Date(row.message_timestamp).getTime() / 1000),
+  },
+  {
+    label: '',
+    align: 'left' as const,
+    width: '100%',
+    render: () => null,
+  },
+]
+
+const purchaseColumns = () => [
+  {
+    label: 'AMOUNT',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) => (
+      <span style={{ color: '#22c55e' }}>{formatCredits(row.amount)}</span>
+    ),
+  },
+  {
+    label: 'BONUS',
+    align: 'right' as const,
+    render: (row: CreditHistoryEntry) =>
+      row.bonus_amount ? (
+        <span style={{ color: '#22c55e' }}>
+          +{formatCredits(row.bonus_amount)}
+        </span>
+      ) : (
+        '-'
+      ),
+  },
+  {
+    label: 'PRICE/CREDIT',
+    align: 'right' as const,
+    render: (row: CreditHistoryEntry) =>
+      row.price ? `$${parseFloat(row.price).toFixed(6)}` : '-',
+  },
+  {
+    label: 'PAYMENT TX',
+    align: 'left' as const,
+    render: (row: CreditHistoryEntry) => <EtherscanLink hash={row.tx_hash} />,
+  },
+  {
+    label: 'PAYMENT MSG',
+    align: 'left' as const,
+    render: (row: CreditHistoryEntry) =>
+      row.origin_ref && row.origin_ref !== 'None' ? (
+        <HashLink
+          hash={row.origin_ref}
+          href={alephExplorerUrl(row.origin_ref, ALEPH_CREDIT_SENDER, 'POST')}
+        />
+      ) : (
+        <span>-</span>
+      ),
+  },
+  {
+    label: 'DATE',
+    align: 'right' as const,
+    sortable: true,
+    render: (row: CreditHistoryEntry) =>
+      getDate(new Date(row.message_timestamp).getTime() / 1000),
+  },
+  {
+    label: '',
+    align: 'left' as const,
+    width: '100%',
+    render: () => null,
+  },
+]
+
+// --- Main component ---
+
 const CreditHistory = ({
   isConnected,
+  accountAddress,
+  knownCrnHashes,
   handleOpenTransferModal,
 }: CreditHistoryProps) => {
   const [open, setOpen] = useState(true)
   const [selectedTab, setSelectedTab] = useState<TabId>('all')
 
-  const [showExpenses, setShowExpenses] = useState(false)
-  const [showPurchases, setShowPurchases] = useState(true)
-  const [showTransfers, setShowTransfers] = useState(true)
+  const [showIncoming, setShowIncoming] = useState(true)
+  const [showOutgoing, setShowOutgoing] = useState(true)
 
   const {
     filteredEntries,
@@ -74,9 +377,9 @@ const CreditHistory = ({
   const tabs: TabsProps['tabs'] = useMemo(
     () => [
       { id: 'all', name: 'All' },
+      { id: 'credit_transfer', name: 'Transfers' },
       { id: 'credit_expense', name: 'Expenses' },
       { id: 'token_transfer', name: 'Purchases' },
-      { id: 'credit_transfer', name: 'Transfers' },
     ],
     [],
   )
@@ -103,30 +406,39 @@ const CreditHistory = ({
     [filters, setFilters],
   )
 
-  const displayEntries = useMemo(() => {
-    if (selectedTab !== 'all') return filteredEntries
+  const showDirectionFilter =
+    selectedTab === 'all' || selectedTab === 'credit_transfer'
 
-    return filteredEntries.filter((entry) => {
-      if (entry.payment_method === 'credit_expense' && !showExpenses)
-        return false
-      if (entry.payment_method === 'token_transfer' && !showPurchases)
-        return false
-      if (entry.payment_method === 'credit_transfer' && !showTransfers)
-        return false
-      return true
-    })
-  }, [filteredEntries, selectedTab, showExpenses, showPurchases, showTransfers])
+  const displayEntries = useMemo(() => {
+    let entries = filteredEntries
+
+    if (showDirectionFilter) {
+      entries = entries.filter((entry) => {
+        if (entry.amount >= 0 && !showIncoming) return false
+        if (entry.amount < 0 && !showOutgoing) return false
+        return true
+      })
+    }
+
+    return entries
+  }, [filteredEntries, showDirectionFilter, showIncoming, showOutgoing])
 
   const hasActiveFilters =
     !!filters.search ||
-    !!filters.payment_method ||
-    (selectedTab === 'all' &&
-      (!showExpenses || !showPurchases || !showTransfers))
+    (showDirectionFilter && (!showIncoming || !showOutgoing))
 
-  const ellipseHash = (hash: string | null) => {
-    if (!hash) return '-'
-    return `${hash.slice(0, 6)}...${hash.slice(-4)}`
-  }
+  const columns = useMemo(() => {
+    switch (selectedTab) {
+      case 'credit_expense':
+        return expenseColumns(accountAddress, knownCrnHashes)
+      case 'credit_transfer':
+        return transferColumns(accountAddress)
+      case 'token_transfer':
+        return purchaseColumns()
+      default:
+        return allColumns()
+    }
+  }, [selectedTab, accountAddress, knownCrnHashes])
 
   return (
     <section tw="px-0 pb-6 pt-6 lg:pb-5">
@@ -171,30 +483,8 @@ const CreditHistory = ({
           />
         </div>
 
-        {/* Search + Checkboxes */}
+        {/* Search + Direction checkboxes */}
         <div tw="flex flex-wrap gap-3 mb-4 items-center">
-          {selectedTab === 'all' && (
-            <>
-              <Checkbox
-                label="Expenses"
-                checked={showExpenses}
-                onChange={() => setShowExpenses(!showExpenses)}
-                size="sm"
-              />
-              <Checkbox
-                label="Purchases"
-                checked={showPurchases}
-                onChange={() => setShowPurchases(!showPurchases)}
-                size="sm"
-              />
-              <Checkbox
-                label="Transfers"
-                checked={showTransfers}
-                onChange={() => setShowTransfers(!showTransfers)}
-                size="sm"
-              />
-            </>
-          )}
           <div tw="flex-1 min-w-[12rem]">
             <TextInput
               name="credit-history-search"
@@ -203,6 +493,24 @@ const CreditHistory = ({
               onChange={handleSearchChange}
             />
           </div>
+          {showDirectionFilter && (
+            <div tw="flex gap-2 items-center">
+              <Checkbox
+                label="In"
+                checked={showIncoming}
+                onChange={() => setShowIncoming(!showIncoming)}
+                size="xs"
+                css="gap: 0.25rem; font-size: 0.75rem;"
+              />
+              <Checkbox
+                label="Out"
+                checked={showOutgoing}
+                onChange={() => setShowOutgoing(!showOutgoing)}
+                size="xs"
+                css="gap: 0.25rem; font-size: 0.75rem;"
+              />
+            </div>
+          )}
         </div>
 
         {/* Table */}
@@ -211,90 +519,7 @@ const CreditHistory = ({
             <StyledTable
               rowKey={(row) => `${page}-${row.credit_ref}-${row.credit_index}`}
               data={displayEntries}
-              columns={[
-                {
-                  label: 'DATE',
-                  align: 'left',
-                  sortable: true,
-                  render: (row) =>
-                    getDate(new Date(row.message_timestamp).getTime() / 1000),
-                },
-                {
-                  label: 'TYPE',
-                  align: 'left',
-                  sortable: true,
-                  render: (row) => {
-                    const label =
-                      PAYMENT_METHOD_LABELS[row.payment_method] ||
-                      row.payment_method
-                    const color =
-                      PAYMENT_METHOD_COLORS[row.payment_method] || 'base2'
-                    return (
-                      <span tw="flex items-center gap-1.5">
-                        <Icon name="circle" gradient={color} size="8px" />
-                        {label}
-                      </span>
-                    )
-                  },
-                },
-                {
-                  label: 'AMOUNT',
-                  align: 'right',
-                  sortable: true,
-                  render: (row) => {
-                    const isNegative = row.amount < 0
-                    return (
-                      <span
-                        style={{
-                          color: isNegative ? '#ef4444' : '#22c55e',
-                        }}
-                      >
-                        {formatCredits(row.amount)}
-                      </span>
-                    )
-                  },
-                },
-                {
-                  label: 'ORIGIN',
-                  align: 'left',
-                  render: (row) => (
-                    <a
-                      href={`https://explorer.aleph.im/address/ETH/${row.origin}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      tw="flex items-center gap-1"
-                      className="text-main0"
-                    >
-                      {ellipseHash(row.origin)}
-                      <Icon name="external-link-square-alt" size="10px" />
-                    </a>
-                  ),
-                },
-                {
-                  label: 'TX HASH',
-                  align: 'left',
-                  render: (row) =>
-                    row.tx_hash ? (
-                      <a
-                        href={`https://etherscan.io/tx/${row.tx_hash}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        tw="flex items-center gap-1"
-                        className="text-main0"
-                      >
-                        {ellipseHash(row.tx_hash)}
-                        <Icon name="external-link-square-alt" size="10px" />
-                      </a>
-                    ) : (
-                      '-'
-                    ),
-                },
-                {
-                  label: 'PROVIDER',
-                  align: 'left',
-                  render: (row) => row.provider,
-                },
-              ]}
+              columns={columns}
             />
           </StyledScrollableTableContainer>
         ) : (

--- a/src/components/pages/console/CreditsDashboardPage/CreditHistory/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/CreditHistory/cmp.tsx
@@ -1,0 +1,345 @@
+import React, { memo, useCallback, useMemo, useState } from 'react'
+import 'twin.macro'
+import {
+  Button,
+  Checkbox,
+  Icon,
+  NoisyContainer,
+  Spinner,
+  Tabs,
+  TabsProps,
+  TextInput,
+} from '@aleph-front/core'
+import { StyledTable } from '@/components/common/EntityTable/styles'
+import ToggleDashboard from '@/components/common/ToggleDashboard'
+import { SectionTitle } from '@/components/common/CompositeTitle'
+import { useCreditHistory } from '@/hooks/common/useCreditHistory'
+import { formatCredits, getDate } from '@/helpers/utils'
+import { StyledSectionHeader, StyledScrollableTableContainer } from '../styles'
+import { CreditHistoryProps } from './types'
+
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  credit_expense: 'Expense',
+  token_transfer: 'Purchase',
+  credit_transfer: 'Transfer',
+}
+
+const PAYMENT_METHOD_COLORS: Record<string, string> = {
+  credit_expense: 'error',
+  token_transfer: 'success',
+  credit_transfer: 'info',
+}
+
+type TabId = 'all' | 'credit_expense' | 'token_transfer' | 'credit_transfer'
+
+const EmptyTablePlaceholder = ({
+  message,
+  hasFilters,
+}: {
+  message: string
+  hasFilters?: boolean
+}) => (
+  <NoisyContainer tw="text-center py-8">
+    <Icon name="info-circle" color="base2" size="lg" tw="mb-3" />
+    <p className="text-base2 tp-body1">{message}</p>
+    {hasFilters && (
+      <p className="text-base2 tp-body3" tw="mt-2">
+        Try removing some filters to see more data.
+      </p>
+    )}
+  </NoisyContainer>
+)
+
+const CreditHistory = ({
+  isConnected,
+  handleOpenTransferModal,
+}: CreditHistoryProps) => {
+  const [open, setOpen] = useState(true)
+  const [selectedTab, setSelectedTab] = useState<TabId>('all')
+
+  const [showExpenses, setShowExpenses] = useState(false)
+  const [showPurchases, setShowPurchases] = useState(true)
+  const [showTransfers, setShowTransfers] = useState(true)
+
+  const {
+    filteredEntries,
+    loading,
+    page,
+    setPage,
+    totalPages,
+    filters,
+    setFilters,
+  } = useCreditHistory()
+
+  const tabs: TabsProps['tabs'] = useMemo(
+    () => [
+      { id: 'all', name: 'All' },
+      { id: 'credit_expense', name: 'Expenses' },
+      { id: 'token_transfer', name: 'Purchases' },
+      { id: 'credit_transfer', name: 'Transfers' },
+    ],
+    [],
+  )
+
+  const handleTabChange = useCallback(
+    (tabId: string) => {
+      const tab = tabId as TabId
+      setSelectedTab(tab)
+
+      if (tab === 'all') {
+        setFilters({ ...filters, payment_method: undefined })
+      } else {
+        setFilters({ ...filters, payment_method: tab })
+      }
+      setPage(1)
+    },
+    [filters, setFilters, setPage],
+  )
+
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFilters({ ...filters, search: e.target.value })
+    },
+    [filters, setFilters],
+  )
+
+  const displayEntries = useMemo(() => {
+    if (selectedTab !== 'all') return filteredEntries
+
+    return filteredEntries.filter((entry) => {
+      if (entry.payment_method === 'credit_expense' && !showExpenses)
+        return false
+      if (entry.payment_method === 'token_transfer' && !showPurchases)
+        return false
+      if (entry.payment_method === 'credit_transfer' && !showTransfers)
+        return false
+      return true
+    })
+  }, [filteredEntries, selectedTab, showExpenses, showPurchases, showTransfers])
+
+  const hasActiveFilters =
+    !!filters.search ||
+    !!filters.payment_method ||
+    (selectedTab === 'all' &&
+      (!showExpenses || !showPurchases || !showTransfers))
+
+  const ellipseHash = (hash: string | null) => {
+    if (!hash) return '-'
+    return `${hash.slice(0, 6)}...${hash.slice(-4)}`
+  }
+
+  return (
+    <section tw="px-0 pb-6 pt-6 lg:pb-5">
+      <StyledSectionHeader>
+        <SectionTitle>
+          <span tw="flex items-center gap-3">
+            Credit History
+            {loading && <Spinner size="1.5em" color="main0" />}
+          </span>
+        </SectionTitle>
+        <Button
+          variant="secondary"
+          kind="flat"
+          tw="bg-white!"
+          disabled={!isConnected}
+          onClick={handleOpenTransferModal}
+        >
+          Transfer Credits
+          <Icon name="exchange" />
+        </Button>
+      </StyledSectionHeader>
+
+      <ToggleDashboard
+        open={open}
+        setOpen={setOpen}
+        toggleButton={{
+          children: (
+            <>
+              Show history <Icon name="clock" />
+            </>
+          ),
+          disabled: !isConnected,
+        }}
+      >
+        {/* Tabs */}
+        <div tw="px-0 pb-3">
+          <Tabs
+            selected={selectedTab}
+            align="left"
+            onTabChange={handleTabChange}
+            tabs={tabs}
+          />
+        </div>
+
+        {/* Search + Checkboxes */}
+        <div tw="flex flex-wrap gap-3 mb-4 items-center">
+          {selectedTab === 'all' && (
+            <>
+              <Checkbox
+                label="Expenses"
+                checked={showExpenses}
+                onChange={() => setShowExpenses(!showExpenses)}
+                size="sm"
+              />
+              <Checkbox
+                label="Purchases"
+                checked={showPurchases}
+                onChange={() => setShowPurchases(!showPurchases)}
+                size="sm"
+              />
+              <Checkbox
+                label="Transfers"
+                checked={showTransfers}
+                onChange={() => setShowTransfers(!showTransfers)}
+                size="sm"
+              />
+            </>
+          )}
+          <div tw="flex-1 min-w-[12rem]">
+            <TextInput
+              name="credit-history-search"
+              placeholder="Search..."
+              value={filters.search || ''}
+              onChange={handleSearchChange}
+            />
+          </div>
+        </div>
+
+        {/* Table */}
+        {displayEntries.length > 0 ? (
+          <StyledScrollableTableContainer $maxHeight="32rem">
+            <StyledTable
+              rowKey={(row) => `${page}-${row.credit_ref}-${row.credit_index}`}
+              data={displayEntries}
+              columns={[
+                {
+                  label: 'DATE',
+                  align: 'left',
+                  sortable: true,
+                  render: (row) =>
+                    getDate(new Date(row.message_timestamp).getTime() / 1000),
+                },
+                {
+                  label: 'TYPE',
+                  align: 'left',
+                  sortable: true,
+                  render: (row) => {
+                    const label =
+                      PAYMENT_METHOD_LABELS[row.payment_method] ||
+                      row.payment_method
+                    const color =
+                      PAYMENT_METHOD_COLORS[row.payment_method] || 'base2'
+                    return (
+                      <span tw="flex items-center gap-1.5">
+                        <Icon name="circle" gradient={color} size="8px" />
+                        {label}
+                      </span>
+                    )
+                  },
+                },
+                {
+                  label: 'AMOUNT',
+                  align: 'right',
+                  sortable: true,
+                  render: (row) => {
+                    const isNegative = row.amount < 0
+                    return (
+                      <span
+                        style={{
+                          color: isNegative ? '#ef4444' : '#22c55e',
+                        }}
+                      >
+                        {formatCredits(row.amount)}
+                      </span>
+                    )
+                  },
+                },
+                {
+                  label: 'ORIGIN',
+                  align: 'left',
+                  render: (row) => (
+                    <a
+                      href={`https://explorer.aleph.im/address/ETH/${row.origin}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      tw="flex items-center gap-1"
+                      className="text-main0"
+                    >
+                      {ellipseHash(row.origin)}
+                      <Icon name="external-link-square-alt" size="10px" />
+                    </a>
+                  ),
+                },
+                {
+                  label: 'TX HASH',
+                  align: 'left',
+                  render: (row) =>
+                    row.tx_hash ? (
+                      <a
+                        href={`https://etherscan.io/tx/${row.tx_hash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        tw="flex items-center gap-1"
+                        className="text-main0"
+                      >
+                        {ellipseHash(row.tx_hash)}
+                        <Icon name="external-link-square-alt" size="10px" />
+                      </a>
+                    ) : (
+                      '-'
+                    ),
+                },
+                {
+                  label: 'PROVIDER',
+                  align: 'left',
+                  render: (row) => row.provider,
+                },
+              ]}
+            />
+          </StyledScrollableTableContainer>
+        ) : (
+          <EmptyTablePlaceholder
+            message={
+              hasActiveFilters
+                ? 'No entries match the current filters.'
+                : 'No credit history entries found.'
+            }
+            hasFilters={hasActiveFilters}
+          />
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div tw="flex items-center justify-center gap-4 mt-4">
+            <Button
+              color="main0"
+              kind="functional"
+              variant="secondary"
+              size="md"
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+            >
+              <Icon name="angle-left" />
+            </Button>
+            <span className="tp-body3">
+              Page {page} of {totalPages}
+            </span>
+            <Button
+              color="main0"
+              kind="functional"
+              variant="secondary"
+              size="md"
+              disabled={page >= totalPages}
+              onClick={() => setPage(page + 1)}
+            >
+              <Icon name="angle-right" />
+            </Button>
+          </div>
+        )}
+      </ToggleDashboard>
+    </section>
+  )
+}
+CreditHistory.displayName = 'CreditHistory'
+
+export default memo(CreditHistory)

--- a/src/components/pages/console/CreditsDashboardPage/CreditHistory/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/CreditHistory/cmp.tsx
@@ -273,7 +273,7 @@ const transferColumns = (accountAddress?: string) => [
     render: (row: CreditHistoryEntry) =>
       row.expiration_date
         ? getDate(new Date(row.expiration_date).getTime() / 1000)
-        : 'None',
+        : '-',
   },
   {
     label: 'DATE',

--- a/src/components/pages/console/CreditsDashboardPage/CreditHistory/index.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditHistory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/console/CreditsDashboardPage/CreditHistory/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditHistory/types.ts
@@ -1,0 +1,4 @@
+export type CreditHistoryProps = {
+  isConnected: boolean
+  handleOpenTransferModal: () => void
+}

--- a/src/components/pages/console/CreditsDashboardPage/CreditHistory/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditHistory/types.ts
@@ -1,4 +1,6 @@
 export type CreditHistoryProps = {
   isConnected: boolean
+  accountAddress?: string
+  knownCrnHashes: Set<string>
   handleOpenTransferModal: () => void
 }

--- a/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/cmp.tsx
@@ -1,0 +1,361 @@
+import React, { memo, useMemo, useState } from 'react'
+import 'twin.macro'
+import { useTheme } from 'styled-components'
+import { NoisyContainer, Icon, ColorDot, TextGradient } from '@aleph-front/core'
+import {
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import { SVGGradients } from '@/components/common/charts'
+import Skeleton from '@/components/common/Skeleton'
+import ToggleDashboard from '@/components/common/ToggleDashboard'
+import { formatCredits } from '@/helpers/utils'
+import { SectionTitle } from '@/components/common/CompositeTitle'
+import { useCreditCharts } from '../CreditCharts/hook'
+import { CreditStatsHeaderProps } from './types'
+
+const CreditStatsHeader = ({
+  isConnected,
+  accountCreditBalance,
+  costsSummary,
+  costsResources,
+  costsLoading,
+}: CreditStatsHeaderProps) => {
+  const theme = useTheme()
+  const [detailsOpen, setDetailsOpen] = useState(true)
+  const totalSpent = costsSummary?.total_consumed_credits
+  const disabledColor = theme.color.disabled2
+
+  const expenseRates = useMemo(() => {
+    if (!costsSummary) return null
+    const hourly = parseFloat(costsSummary.total_cost_credit)
+    return {
+      hourly,
+      daily: hourly * 24,
+      monthly: hourly * 24 * 30,
+      yearly: hourly * 24 * 365,
+    }
+  }, [costsSummary])
+
+  const {
+    serviceTypePieData,
+    expenseSharePieData,
+    dailyChartData,
+    chartLoading,
+  } = useCreditCharts(costsResources)
+
+  const isLoading = costsLoading || chartLoading
+
+  return (
+    <section tw="px-0 pb-6 pt-12 lg:pb-5">
+      <SectionTitle>Credits Overview</SectionTitle>
+
+      {/* Stats cards */}
+      <div tw="flex flex-wrap gap-4 items-stretch mt-3">
+        <NoisyContainer tw="flex-1 min-w-[12rem]">
+          <p className="tp-info text-base2">BALANCE</p>
+          {accountCreditBalance !== undefined ? (
+            <p className="text-main0 tp-h7" tw="mt-1">
+              {formatCredits(accountCreditBalance)}
+            </p>
+          ) : (
+            <Skeleton width="5rem" height="1.5rem" />
+          )}
+        </NoisyContainer>
+
+        <NoisyContainer tw="flex-1 min-w-[12rem]">
+          <p className="tp-info text-base2">TOTAL SPENT</p>
+          {costsLoading ? (
+            <Skeleton width="5rem" height="1.5rem" />
+          ) : (
+            <p className="text-main0 tp-h7" tw="mt-1">
+              {formatCredits(totalSpent)}
+            </p>
+          )}
+        </NoisyContainer>
+
+        <NoisyContainer tw="flex-1 min-w-[18rem]">
+          <p className="tp-info text-base2">EXPENSE RATES</p>
+          {costsLoading ? (
+            <Skeleton width="100%" height="1.5rem" />
+          ) : expenseRates ? (
+            <div tw="flex flex-wrap gap-4 mt-1">
+              <div>
+                <p className="tp-info text-base2" tw="text-10">
+                  /HOUR
+                </p>
+                <p className="text-main0 tp-body1">
+                  {formatCredits(expenseRates.hourly * 1_000_000)}
+                </p>
+              </div>
+              <div>
+                <p className="tp-info text-base2" tw="text-10">
+                  /DAY
+                </p>
+                <p className="text-main0 tp-body1">
+                  {formatCredits(expenseRates.daily * 1_000_000)}
+                </p>
+              </div>
+              <div>
+                <p className="tp-info text-base2" tw="text-10">
+                  /MONTH
+                </p>
+                <p className="text-main0 tp-body1">
+                  {formatCredits(expenseRates.monthly * 1_000_000)}
+                </p>
+              </div>
+              <div>
+                <p className="tp-info text-base2" tw="text-10">
+                  /YEAR
+                </p>
+                <p className="text-main0 tp-body1">
+                  {formatCredits(expenseRates.yearly * 1_000_000)}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <p className="text-base2 tp-body1" tw="mt-1">
+              No active services
+            </p>
+          )}
+        </NoisyContainer>
+      </div>
+
+      {/* Charts (collapsible, merged into this section) */}
+      <ToggleDashboard
+        open={detailsOpen}
+        setOpen={setDetailsOpen}
+        toggleButton={{
+          children: (
+            <>
+              Show details <Icon name="chart-pie" />
+            </>
+          ),
+          disabled: !isConnected,
+        }}
+      >
+        {isLoading ? (
+          <Skeleton width="100%" height="16rem" />
+        ) : (
+          <div tw="flex gap-6 flex-wrap">
+            {/* Pie Charts */}
+            <NoisyContainer tw="flex-1 min-w-[20rem]">
+              <div tw="flex gap-6 flex-wrap justify-around">
+                <div tw="flex flex-col items-center">
+                  <TextGradient
+                    forwardedAs="h3"
+                    type="info"
+                    color="main0"
+                    tw="m-0 mb-2"
+                  >
+                    By Service Type
+                  </TextGradient>
+                  {serviceTypePieData.length > 0 ? (
+                    <>
+                      <PieChart width={120} height={120}>
+                        <defs>
+                          <SVGGradients data={serviceTypePieData} />
+                        </defs>
+                        <Pie
+                          data={[{ v: 1 }]}
+                          dataKey="v"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                          isAnimationActive={false}
+                          fill={disabledColor}
+                        />
+                        <Pie
+                          data={serviceTypePieData}
+                          dataKey="value"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                        >
+                          {serviceTypePieData.map((entry) => {
+                            const color = `gr-${entry.gradient}`
+                            const fill = entry.gradient
+                              ? `url(#${color})`
+                              : entry.color
+                                ? theme.color[entry.color] || entry.color
+                                : undefined
+                            return <Cell key={entry.label} fill={fill} />
+                          })}
+                        </Pie>
+                      </PieChart>
+                      <div tw="mt-2 flex flex-col gap-2">
+                        {serviceTypePieData.map((entry) => (
+                          <div key={entry.label} tw="flex items-center gap-2">
+                            <ColorDot
+                              $gradient={entry.gradient}
+                              $size="0.75rem"
+                            />
+                            <span className="tp-body3">
+                              {entry.value} {entry.label}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-base2 tp-body3">No services</p>
+                  )}
+                </div>
+
+                <div tw="flex flex-col items-center">
+                  <TextGradient
+                    forwardedAs="h3"
+                    type="info"
+                    color="main0"
+                    tw="m-0 mb-2"
+                  >
+                    Expense Share
+                  </TextGradient>
+                  {expenseSharePieData.length > 0 ? (
+                    <>
+                      <PieChart width={120} height={120}>
+                        <defs>
+                          <SVGGradients data={expenseSharePieData} />
+                        </defs>
+                        <Pie
+                          data={[{ v: 1 }]}
+                          dataKey="v"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                          isAnimationActive={false}
+                          fill={disabledColor}
+                        />
+                        <Pie
+                          data={expenseSharePieData}
+                          dataKey="value"
+                          stroke="transparent"
+                          innerRadius="72%"
+                          outerRadius="100%"
+                          startAngle={360 + 90}
+                          endAngle={0 + 90}
+                        >
+                          {expenseSharePieData.map((entry) => {
+                            const color = `gr-${entry.gradient}`
+                            const fill = entry.gradient
+                              ? `url(#${color})`
+                              : entry.color
+                                ? theme.color[entry.color] || entry.color
+                                : undefined
+                            return <Cell key={entry.label} fill={fill} />
+                          })}
+                        </Pie>
+                      </PieChart>
+                      <div tw="mt-2 flex flex-col gap-2">
+                        {expenseSharePieData.map((entry) => (
+                          <div key={entry.label} tw="flex items-center gap-2">
+                            <ColorDot
+                              $gradient={entry.gradient}
+                              $size="0.75rem"
+                            />
+                            <span className="tp-body3">{entry.label}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-base2 tp-body3">No expenses</p>
+                  )}
+                </div>
+              </div>
+            </NoisyContainer>
+
+            {/* Line Chart */}
+            <NoisyContainer tw="flex-1 min-w-[20rem]">
+              <TextGradient
+                forwardedAs="h3"
+                type="info"
+                color="main0"
+                tw="m-0 mb-4"
+              >
+                30-Day Activity
+              </TextGradient>
+              {dailyChartData.length > 0 ? (
+                <ResponsiveContainer width="100%" height={250}>
+                  <LineChart data={dailyChartData}>
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(v: string) => v.slice(5)}
+                      stroke={theme.color.base2}
+                    />
+                    <YAxis
+                      yAxisId="expenses"
+                      orientation="left"
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(v: number) => formatCredits(v, 0)}
+                      stroke={theme.color.base2}
+                    />
+                    <YAxis
+                      yAxisId="balance"
+                      orientation="right"
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(v: number) => formatCredits(v, 0)}
+                      stroke={theme.color.base2}
+                    />
+                    <Tooltip
+                      formatter={(value: number, name: string) => [
+                        formatCredits(value),
+                        name,
+                      ]}
+                      labelFormatter={(label: string) => `Date: ${label}`}
+                      contentStyle={{
+                        background: theme.color.base0,
+                        border: `1px solid ${theme.color.base2}`,
+                      }}
+                    />
+                    <Legend />
+                    <Line
+                      yAxisId="expenses"
+                      type="monotone"
+                      dataKey="expenses"
+                      name="Daily Expenses"
+                      stroke="#a855f7"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                    <Line
+                      yAxisId="balance"
+                      type="monotone"
+                      dataKey="balance"
+                      name="Balance"
+                      stroke="#22d3ee"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              ) : (
+                <p className="text-base2 tp-body3">
+                  No activity in the last 30 days
+                </p>
+              )}
+            </NoisyContainer>
+          </div>
+        )}
+      </ToggleDashboard>
+    </section>
+  )
+}
+CreditStatsHeader.displayName = 'CreditStatsHeader'
+
+export default memo(CreditStatsHeader)

--- a/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/cmp.tsx
@@ -2,6 +2,7 @@ import React, { memo, useMemo, useState } from 'react'
 import 'twin.macro'
 import { useTheme } from 'styled-components'
 import { NoisyContainer, Icon, ColorDot, TextGradient } from '@aleph-front/core'
+import BorderBox from '@/components/common/BorderBox'
 import {
   PieChart,
   Pie,
@@ -17,6 +18,7 @@ import {
 import { SVGGradients } from '@/components/common/charts'
 import Skeleton from '@/components/common/Skeleton'
 import ToggleDashboard from '@/components/common/ToggleDashboard'
+import { Card1 } from '@/components/common/Card1'
 import { formatCredits } from '@/helpers/utils'
 import { SectionTitle } from '@/components/common/CompositeTitle'
 import { useCreditCharts } from '../CreditCharts/hook'
@@ -34,16 +36,34 @@ const CreditStatsHeader = ({
   const totalSpent = costsSummary?.total_consumed_credits
   const disabledColor = theme.color.disabled2
 
+  // total_cost_credit is in credits per second
   const expenseRates = useMemo(() => {
     if (!costsSummary) return null
-    const hourly = parseFloat(costsSummary.total_cost_credit)
+    const perSecond = parseFloat(costsSummary.total_cost_credit)
     return {
-      hourly,
-      daily: hourly * 24,
-      monthly: hourly * 24 * 30,
-      yearly: hourly * 24 * 365,
+      hourly: perSecond * 3600,
+      daily: perSecond * 3600 * 24,
+      monthly: perSecond * 3600 * 24 * 30,
+      yearly: perSecond * 3600 * 24 * 365,
     }
   }, [costsSummary])
+
+  // Calculate how long the balance will last at current rate
+  const runRate = useMemo(() => {
+    if (!expenseRates || !accountCreditBalance || accountCreditBalance <= 0)
+      return null
+    if (expenseRates.hourly <= 0) return null
+
+    const totalHours = accountCreditBalance / expenseRates.hourly
+    const years = Math.floor(totalHours / (24 * 365))
+    const months = Math.floor((totalHours % (24 * 365)) / (24 * 30))
+    const days = Math.floor((totalHours % (24 * 30)) / 24)
+    const hours = Math.floor(totalHours % 24)
+
+    return { totalHours, years, months, days, hours }
+  }, [expenseRates, accountCreditBalance])
+
+  const isLowBalance = runRate && runRate.totalHours < 72
 
   const {
     serviceTypePieData,
@@ -59,75 +79,144 @@ const CreditStatsHeader = ({
       <SectionTitle>Credits Overview</SectionTitle>
 
       {/* Stats cards */}
-      <div tw="flex flex-wrap gap-4 items-stretch mt-3">
-        <NoisyContainer tw="flex-1 min-w-[12rem]">
-          <p className="tp-info text-base2">BALANCE</p>
-          {accountCreditBalance !== undefined ? (
-            <p className="text-main0 tp-h7" tw="mt-1">
-              {formatCredits(accountCreditBalance)}
-            </p>
-          ) : (
-            <Skeleton width="5rem" height="1.5rem" />
-          )}
-        </NoisyContainer>
+      <div tw="flex flex-wrap gap-6 items-stretch mt-3">
+        <div style={{ flex: '1 1 12rem', minWidth: '12rem', display: 'flex' }}>
+          <NoisyContainer tw="w-full">
+            <p className="tp-info text-base2">BALANCE</p>
+            {accountCreditBalance !== undefined ? (
+              <p className="text-main0 tp-h7" tw="mt-1">
+                {formatCredits(accountCreditBalance)}
+              </p>
+            ) : (
+              <Skeleton width="5rem" height="1.5rem" />
+            )}
+          </NoisyContainer>
+        </div>
 
-        <NoisyContainer tw="flex-1 min-w-[12rem]">
-          <p className="tp-info text-base2">TOTAL SPENT</p>
-          {costsLoading ? (
-            <Skeleton width="5rem" height="1.5rem" />
-          ) : (
-            <p className="text-main0 tp-h7" tw="mt-1">
-              {formatCredits(totalSpent)}
-            </p>
-          )}
-        </NoisyContainer>
+        <div style={{ flex: '1 1 12rem', minWidth: '12rem', display: 'flex' }}>
+          <NoisyContainer tw="w-full">
+            <p className="tp-info text-base2">TOTAL SPENT</p>
+            {costsLoading ? (
+              <Skeleton width="5rem" height="1.5rem" />
+            ) : (
+              <p className="text-main0 tp-h7" tw="mt-1">
+                {formatCredits(totalSpent)}
+              </p>
+            )}
+          </NoisyContainer>
+        </div>
 
-        <NoisyContainer tw="flex-1 min-w-[18rem]">
-          <p className="tp-info text-base2">EXPENSE RATES</p>
-          {costsLoading ? (
-            <Skeleton width="100%" height="1.5rem" />
-          ) : expenseRates ? (
-            <div tw="flex flex-wrap gap-4 mt-1">
-              <div>
-                <p className="tp-info text-base2" tw="text-10">
-                  /HOUR
-                </p>
-                <p className="text-main0 tp-body1">
-                  {formatCredits(expenseRates.hourly * 1_000_000)}
-                </p>
+        <div style={{ flex: '2 1 20rem', minWidth: '20rem', display: 'flex' }}>
+          <NoisyContainer tw="w-full">
+            <p className="tp-info text-base2">EXPENSE RATES</p>
+            {costsLoading ? (
+              <Skeleton width="100%" height="1.5rem" />
+            ) : expenseRates ? (
+              <div
+                tw="flex flex-wrap gap-4 mt-1 justify-between"
+                style={{ maxWidth: '28rem' }}
+              >
+                <div>
+                  <p className="text-main0 tp-h7" tw="text-16">
+                    {formatCredits(expenseRates.hourly)}
+                  </p>
+                  <p className="tp-info text-base2" tw="text-10">
+                    /HOUR
+                  </p>
+                </div>
+                <div>
+                  <p className="text-main0 tp-h7" tw="text-16">
+                    {formatCredits(expenseRates.daily)}
+                  </p>
+                  <p className="tp-info text-base2" tw="text-10">
+                    /DAY
+                  </p>
+                </div>
+                <div>
+                  <p className="text-main0 tp-h7" tw="text-16">
+                    {formatCredits(expenseRates.monthly)}
+                  </p>
+                  <p className="tp-info text-base2" tw="text-10">
+                    /MONTH
+                  </p>
+                </div>
+                <div>
+                  <p className="text-main0 tp-h7" tw="text-16">
+                    {formatCredits(expenseRates.yearly)}
+                  </p>
+                  <p className="tp-info text-base2" tw="text-10">
+                    /YEAR
+                  </p>
+                </div>
               </div>
-              <div>
-                <p className="tp-info text-base2" tw="text-10">
-                  /DAY
-                </p>
-                <p className="text-main0 tp-body1">
-                  {formatCredits(expenseRates.daily * 1_000_000)}
-                </p>
-              </div>
-              <div>
-                <p className="tp-info text-base2" tw="text-10">
-                  /MONTH
-                </p>
-                <p className="text-main0 tp-body1">
-                  {formatCredits(expenseRates.monthly * 1_000_000)}
-                </p>
-              </div>
-              <div>
-                <p className="tp-info text-base2" tw="text-10">
-                  /YEAR
-                </p>
-                <p className="text-main0 tp-body1">
-                  {formatCredits(expenseRates.yearly * 1_000_000)}
-                </p>
+            ) : (
+              <p className="text-base2 tp-body1" tw="mt-1">
+                No active services
+              </p>
+            )}
+          </NoisyContainer>
+        </div>
+      </div>
+
+      {/* Low balance warning */}
+      {isLowBalance && (
+        <BorderBox $color="error" tw="mt-4 relative" className="tp-body1">
+          <span tw="flex items-center gap-2">
+            <Icon name="exclamation-triangle" />
+            Your balance will run out in less than 72 hours at the current rate.
+            Please top up your credits to avoid service interruptions.
+          </span>
+        </BorderBox>
+      )}
+
+      {/* Run rate duration */}
+      {runRate && !costsLoading && (
+        <div tw="mt-4">
+          <NoisyContainer tw="w-full">
+            <div tw="flex items-center gap-3 flex-wrap">
+              <p className="tp-info text-base2">ESTIMATED RUN TIME</p>
+              <div tw="flex gap-4 items-end">
+                {runRate.years > 0 && (
+                  <div tw="flex items-end gap-1">
+                    <p className="text-main0 tp-h7" tw="text-16">
+                      {runRate.years}
+                    </p>
+                    <p className="tp-info text-base2" tw="text-10">
+                      {runRate.years === 1 ? 'YEAR' : 'YEARS'}
+                    </p>
+                  </div>
+                )}
+                {(runRate.years > 0 || runRate.months > 0) && (
+                  <div tw="flex items-end gap-1">
+                    <p className="text-main0 tp-h7" tw="text-16">
+                      {runRate.months}
+                    </p>
+                    <p className="tp-info text-base2" tw="text-10">
+                      {runRate.months === 1 ? 'MONTH' : 'MONTHS'}
+                    </p>
+                  </div>
+                )}
+                <div tw="flex items-end gap-1">
+                  <p className="text-main0 tp-h7" tw="text-16">
+                    {runRate.days}
+                  </p>
+                  <p className="tp-info text-base2" tw="text-10">
+                    {runRate.days === 1 ? 'DAY' : 'DAYS'}
+                  </p>
+                </div>
+                <div tw="flex items-end gap-1">
+                  <p className="text-main0 tp-h7" tw="text-16">
+                    {runRate.hours}
+                  </p>
+                  <p className="tp-info text-base2" tw="text-10">
+                    {runRate.hours === 1 ? 'HOUR' : 'HOURS'}
+                  </p>
+                </div>
               </div>
             </div>
-          ) : (
-            <p className="text-base2 tp-body1" tw="mt-1">
-              No active services
-            </p>
-          )}
-        </NoisyContainer>
-      </div>
+          </NoisyContainer>
+        </div>
+      )}
 
       {/* Charts (collapsible, merged into this section) */}
       <ToggleDashboard
@@ -145,10 +234,12 @@ const CreditStatsHeader = ({
         {isLoading ? (
           <Skeleton width="100%" height="16rem" />
         ) : (
-          <div tw="flex gap-6 flex-wrap">
+          <div tw="flex gap-6 flex-wrap items-stretch">
             {/* Pie Charts */}
-            <NoisyContainer tw="flex-1 min-w-[20rem]">
-              <div tw="flex gap-6 flex-wrap justify-around">
+            <div
+              style={{ flex: '1 1 12rem', minWidth: '12rem', display: 'flex' }}
+            >
+              <Card1 tw="w-full">
                 <div tw="flex flex-col items-center">
                   <TextGradient
                     forwardedAs="h3"
@@ -158,62 +249,75 @@ const CreditStatsHeader = ({
                   >
                     By Service Type
                   </TextGradient>
+                  <PieChart width={120} height={120}>
+                    {serviceTypePieData.length > 0 && (
+                      <defs>
+                        <SVGGradients data={serviceTypePieData} />
+                      </defs>
+                    )}
+                    <Pie
+                      data={[{ v: 1 }]}
+                      dataKey="v"
+                      stroke="transparent"
+                      innerRadius="72%"
+                      outerRadius="100%"
+                      startAngle={360 + 90}
+                      endAngle={0 + 90}
+                      isAnimationActive={false}
+                      fill={disabledColor}
+                    />
+                    {serviceTypePieData.length > 0 && (
+                      <Pie
+                        data={serviceTypePieData}
+                        dataKey="value"
+                        stroke="transparent"
+                        innerRadius="72%"
+                        outerRadius="100%"
+                        startAngle={360 + 90}
+                        endAngle={0 + 90}
+                      >
+                        {serviceTypePieData.map((entry) => {
+                          const color = `gr-${entry.gradient}`
+                          const fill = entry.gradient
+                            ? `url(#${color})`
+                            : entry.color
+                              ? theme.color[entry.color] || entry.color
+                              : undefined
+                          return <Cell key={entry.label} fill={fill} />
+                        })}
+                      </Pie>
+                    )}
+                  </PieChart>
                   {serviceTypePieData.length > 0 ? (
-                    <>
-                      <PieChart width={120} height={120}>
-                        <defs>
-                          <SVGGradients data={serviceTypePieData} />
-                        </defs>
-                        <Pie
-                          data={[{ v: 1 }]}
-                          dataKey="v"
-                          stroke="transparent"
-                          innerRadius="72%"
-                          outerRadius="100%"
-                          startAngle={360 + 90}
-                          endAngle={0 + 90}
-                          isAnimationActive={false}
-                          fill={disabledColor}
-                        />
-                        <Pie
-                          data={serviceTypePieData}
-                          dataKey="value"
-                          stroke="transparent"
-                          innerRadius="72%"
-                          outerRadius="100%"
-                          startAngle={360 + 90}
-                          endAngle={0 + 90}
-                        >
-                          {serviceTypePieData.map((entry) => {
-                            const color = `gr-${entry.gradient}`
-                            const fill = entry.gradient
-                              ? `url(#${color})`
-                              : entry.color
-                                ? theme.color[entry.color] || entry.color
-                                : undefined
-                            return <Cell key={entry.label} fill={fill} />
-                          })}
-                        </Pie>
-                      </PieChart>
-                      <div tw="mt-2 flex flex-col gap-2">
-                        {serviceTypePieData.map((entry) => (
-                          <div key={entry.label} tw="flex items-center gap-2">
-                            <ColorDot
-                              $gradient={entry.gradient}
-                              $size="0.75rem"
-                            />
-                            <span className="tp-body3">
-                              {entry.value} {entry.label}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </>
+                    <div
+                      tw="mt-2 flex flex-col gap-2"
+                      style={{ maxHeight: '8rem', overflowY: 'auto' }}
+                    >
+                      {serviceTypePieData.map((entry) => (
+                        <div key={entry.label} tw="flex items-center gap-2">
+                          <ColorDot
+                            $gradient={entry.gradient}
+                            $size="0.75rem"
+                          />
+                          <span className="tp-body3">
+                            {entry.value} {entry.label}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
                   ) : (
-                    <p className="text-base2 tp-body3">No services</p>
+                    <p className="text-base2 tp-body3" tw="mt-2">
+                      No services
+                    </p>
                   )}
                 </div>
+              </Card1>
+            </div>
 
+            <div
+              style={{ flex: '1 1 12rem', minWidth: '12rem', display: 'flex' }}
+            >
+              <Card1 tw="w-full">
                 <div tw="flex flex-col items-center">
                   <TextGradient
                     forwardedAs="h3"
@@ -223,133 +327,146 @@ const CreditStatsHeader = ({
                   >
                     Expense Share
                   </TextGradient>
+                  <PieChart width={120} height={120}>
+                    {expenseSharePieData.length > 0 && (
+                      <defs>
+                        <SVGGradients data={expenseSharePieData} />
+                      </defs>
+                    )}
+                    <Pie
+                      data={[{ v: 1 }]}
+                      dataKey="v"
+                      stroke="transparent"
+                      innerRadius="72%"
+                      outerRadius="100%"
+                      startAngle={360 + 90}
+                      endAngle={0 + 90}
+                      isAnimationActive={false}
+                      fill={disabledColor}
+                    />
+                    {expenseSharePieData.length > 0 && (
+                      <Pie
+                        data={expenseSharePieData}
+                        dataKey="value"
+                        stroke="transparent"
+                        innerRadius="72%"
+                        outerRadius="100%"
+                        startAngle={360 + 90}
+                        endAngle={0 + 90}
+                      >
+                        {expenseSharePieData.map((entry) => {
+                          const color = `gr-${entry.gradient}`
+                          const fill = entry.gradient
+                            ? `url(#${color})`
+                            : entry.color
+                              ? theme.color[entry.color] || entry.color
+                              : undefined
+                          return <Cell key={entry.label} fill={fill} />
+                        })}
+                      </Pie>
+                    )}
+                  </PieChart>
                   {expenseSharePieData.length > 0 ? (
-                    <>
-                      <PieChart width={120} height={120}>
-                        <defs>
-                          <SVGGradients data={expenseSharePieData} />
-                        </defs>
-                        <Pie
-                          data={[{ v: 1 }]}
-                          dataKey="v"
-                          stroke="transparent"
-                          innerRadius="72%"
-                          outerRadius="100%"
-                          startAngle={360 + 90}
-                          endAngle={0 + 90}
-                          isAnimationActive={false}
-                          fill={disabledColor}
-                        />
-                        <Pie
-                          data={expenseSharePieData}
-                          dataKey="value"
-                          stroke="transparent"
-                          innerRadius="72%"
-                          outerRadius="100%"
-                          startAngle={360 + 90}
-                          endAngle={0 + 90}
-                        >
-                          {expenseSharePieData.map((entry) => {
-                            const color = `gr-${entry.gradient}`
-                            const fill = entry.gradient
-                              ? `url(#${color})`
-                              : entry.color
-                                ? theme.color[entry.color] || entry.color
-                                : undefined
-                            return <Cell key={entry.label} fill={fill} />
-                          })}
-                        </Pie>
-                      </PieChart>
-                      <div tw="mt-2 flex flex-col gap-2">
-                        {expenseSharePieData.map((entry) => (
-                          <div key={entry.label} tw="flex items-center gap-2">
-                            <ColorDot
-                              $gradient={entry.gradient}
-                              $size="0.75rem"
-                            />
-                            <span className="tp-body3">{entry.label}</span>
-                          </div>
-                        ))}
-                      </div>
-                    </>
+                    <div
+                      tw="mt-2 flex flex-col gap-2"
+                      style={{ maxHeight: '8rem', overflowY: 'auto' }}
+                    >
+                      {expenseSharePieData.map((entry) => (
+                        <div key={entry.label} tw="flex items-center gap-2">
+                          <ColorDot
+                            $gradient={entry.gradient}
+                            $size="0.75rem"
+                          />
+                          <span className="tp-body3">
+                            {entry.displayLabel || entry.label}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
                   ) : (
-                    <p className="text-base2 tp-body3">No expenses</p>
+                    <p className="text-base2 tp-body3" tw="mt-2">
+                      No expenses
+                    </p>
                   )}
                 </div>
-              </div>
-            </NoisyContainer>
+              </Card1>
+            </div>
 
             {/* Line Chart */}
-            <NoisyContainer tw="flex-1 min-w-[20rem]">
-              <TextGradient
-                forwardedAs="h3"
-                type="info"
-                color="main0"
-                tw="m-0 mb-4"
-              >
-                30-Day Activity
-              </TextGradient>
-              {dailyChartData.length > 0 ? (
-                <ResponsiveContainer width="100%" height={250}>
-                  <LineChart data={dailyChartData}>
-                    <XAxis
-                      dataKey="date"
-                      tick={{ fontSize: 10 }}
-                      tickFormatter={(v: string) => v.slice(5)}
-                      stroke={theme.color.base2}
-                    />
-                    <YAxis
-                      yAxisId="expenses"
-                      orientation="left"
-                      tick={{ fontSize: 10 }}
-                      tickFormatter={(v: number) => formatCredits(v, 0)}
-                      stroke={theme.color.base2}
-                    />
-                    <YAxis
-                      yAxisId="balance"
-                      orientation="right"
-                      tick={{ fontSize: 10 }}
-                      tickFormatter={(v: number) => formatCredits(v, 0)}
-                      stroke={theme.color.base2}
-                    />
-                    <Tooltip
-                      formatter={(value: number, name: string) => [
-                        formatCredits(value),
-                        name,
-                      ]}
-                      labelFormatter={(label: string) => `Date: ${label}`}
-                      contentStyle={{
-                        background: theme.color.base0,
-                        border: `1px solid ${theme.color.base2}`,
-                      }}
-                    />
-                    <Legend />
-                    <Line
-                      yAxisId="expenses"
-                      type="monotone"
-                      dataKey="expenses"
-                      name="Daily Expenses"
-                      stroke="#a855f7"
-                      strokeWidth={2}
-                      dot={false}
-                    />
-                    <Line
-                      yAxisId="balance"
-                      type="monotone"
-                      dataKey="balance"
-                      name="Balance"
-                      stroke="#22d3ee"
-                      strokeWidth={2}
-                      dot={false}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              ) : (
-                <p className="text-base2 tp-body3">
-                  No activity in the last 30 days
-                </p>
-              )}
-            </NoisyContainer>
+            <div
+              style={{ flex: '2 1 20rem', minWidth: '20rem', display: 'flex' }}
+            >
+              <NoisyContainer tw="w-full">
+                <TextGradient
+                  forwardedAs="h3"
+                  type="info"
+                  color="main0"
+                  tw="m-0 mb-4"
+                >
+                  30-Day Activity
+                </TextGradient>
+                {dailyChartData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height={250}>
+                    <LineChart data={dailyChartData}>
+                      <XAxis
+                        dataKey="date"
+                        tick={{ fontSize: 10 }}
+                        tickFormatter={(v: string) => v.slice(5)}
+                        stroke={theme.color.base2}
+                      />
+                      <YAxis
+                        yAxisId="expenses"
+                        orientation="left"
+                        tick={{ fontSize: 10 }}
+                        tickFormatter={(v: number) => formatCredits(v, 0)}
+                        stroke={theme.color.base2}
+                      />
+                      <YAxis
+                        yAxisId="balance"
+                        orientation="right"
+                        tick={{ fontSize: 10 }}
+                        tickFormatter={(v: number) => formatCredits(v, 0)}
+                        stroke={theme.color.base2}
+                      />
+                      <Tooltip
+                        formatter={(value: number, name: string) => [
+                          formatCredits(value),
+                          name,
+                        ]}
+                        labelFormatter={(label: string) => `Date: ${label}`}
+                        contentStyle={{
+                          background: theme.color.base0,
+                          border: `1px solid ${theme.color.base2}`,
+                        }}
+                      />
+                      <Legend />
+                      <Line
+                        yAxisId="expenses"
+                        type="monotone"
+                        dataKey="expenses"
+                        name="Daily Expenses"
+                        stroke="#ef4444"
+                        strokeWidth={3}
+                        dot={false}
+                      />
+                      <Line
+                        yAxisId="balance"
+                        type="monotone"
+                        dataKey="balance"
+                        name="Balance"
+                        stroke="#22c55e"
+                        strokeWidth={3}
+                        dot={false}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <p className="text-base2 tp-body3">
+                    No activity in the last 30 days
+                  </p>
+                )}
+              </NoisyContainer>
+            </div>
           </div>
         )}
       </ToggleDashboard>

--- a/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/index.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/CreditStatsHeader/types.ts
@@ -1,0 +1,9 @@
+import { CostsSummary, CostsResource } from '@/hooks/common/useServiceCosts'
+
+export type CreditStatsHeaderProps = {
+  isConnected: boolean
+  accountCreditBalance?: number
+  costsSummary?: CostsSummary
+  costsResources: CostsResource[]
+  costsLoading: boolean
+}

--- a/src/components/pages/console/CreditsDashboardPage/ExpiringBalances/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/ExpiringBalances/cmp.tsx
@@ -1,0 +1,196 @@
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import 'twin.macro'
+import { Icon, NoisyContainer, Spinner } from '@aleph-front/core'
+import { StyledTable } from '@/components/common/EntityTable/styles'
+import ToggleDashboard from '@/components/common/ToggleDashboard'
+import { SectionTitle } from '@/components/common/CompositeTitle'
+import { useAppState } from '@/contexts/appState'
+import { getApiServer } from '@/helpers/server'
+import { formatCredits, getDate } from '@/helpers/utils'
+import { CreditHistoryEntry } from '@/hooks/common/useCreditHistory'
+import { StyledScrollableTableContainer } from '../styles'
+import { ExpiringBalancesProps } from './types'
+
+const EmptyTablePlaceholder = ({ message }: { message: string }) => (
+  <NoisyContainer tw="text-center py-8">
+    <Icon name="info-circle" color="base2" size="lg" tw="mb-3" />
+    <p className="text-base2 tp-body1">{message}</p>
+  </NoisyContainer>
+)
+
+const ellipseHash = (hash: string | null | undefined) => {
+  if (!hash || hash === 'None') return '-'
+  return `${hash.slice(0, 6)}...${hash.slice(-4)}`
+}
+
+const ExpiringBalances = ({ isConnected }: ExpiringBalancesProps) => {
+  const [open, setOpen] = useState(true)
+  const [state] = useAppState()
+  const { account } = state.connection
+
+  const [entries, setEntries] = useState<CreditHistoryEntry[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchExpiringBalances = useCallback(async () => {
+    if (!account?.address) return
+
+    setLoading(true)
+    try {
+      const apiServer = getApiServer()
+      let page = 1
+      let hasMore = true
+      const allEntries: CreditHistoryEntry[] = []
+
+      while (hasMore) {
+        const params = new URLSearchParams({
+          pagination: '200',
+          page: String(page),
+          payment_method: 'credit_transfer',
+        })
+
+        const response = await fetch(
+          `${apiServer}/api/v0/addresses/${account.address}/credit_history?${params}`,
+        )
+
+        if (!response.ok) break
+
+        const data = await response.json()
+        const items: CreditHistoryEntry[] = data.credit_history || []
+
+        allEntries.push(...items)
+
+        if (items.length < 200) {
+          hasMore = false
+        } else {
+          page++
+        }
+      }
+
+      setEntries(allEntries.filter((e) => !!e.expiration_date))
+    } catch (err) {
+      console.error('Error fetching expiring balances:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [account?.address])
+
+  useEffect(() => {
+    fetchExpiringBalances()
+  }, [fetchExpiringBalances])
+
+  const sortedEntries = useMemo(() => {
+    return [...entries].sort((a, b) => {
+      const aDate = a.expiration_date
+        ? new Date(a.expiration_date).getTime()
+        : Infinity
+      const bDate = b.expiration_date
+        ? new Date(b.expiration_date).getTime()
+        : Infinity
+      return aDate - bDate
+    })
+  }, [entries])
+
+  return (
+    <section tw="px-0 pb-6 pt-6 lg:pb-5">
+      <SectionTitle>
+        <span tw="flex items-center gap-3">
+          Expiring Balances
+          {loading && <Spinner size="1.5em" color="main0" />}
+        </span>
+      </SectionTitle>
+      <ToggleDashboard
+        open={open}
+        setOpen={setOpen}
+        toggleButton={{
+          children: (
+            <>
+              Show expiring balances <Icon name="hourglass-half" />
+            </>
+          ),
+          disabled: !isConnected,
+        }}
+      >
+        {sortedEntries.length > 0 ? (
+          <StyledScrollableTableContainer $maxHeight="24rem">
+            <StyledTable
+              rowKey={(row) => `${row.credit_ref}-${row.credit_index}`}
+              data={sortedEntries}
+              columns={[
+                {
+                  label: 'AMOUNT',
+                  align: 'right',
+                  sortable: true,
+                  render: (row) => (
+                    <span style={{ color: '#22c55e' }}>
+                      {formatCredits(row.amount)}
+                    </span>
+                  ),
+                },
+                {
+                  label: 'FROM',
+                  align: 'left',
+                  render: (row) => (
+                    <a
+                      href={`https://explorer.aleph.im/address/ETH/${row.origin}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      tw="flex items-center gap-1"
+                      className="text-main0"
+                    >
+                      {ellipseHash(row.origin)}
+                      <Icon name="external-link-square-alt" size="10px" />
+                    </a>
+                  ),
+                },
+                {
+                  label: 'EXPIRES',
+                  align: 'right',
+                  sortable: true,
+                  render: (row) => {
+                    if (!row.expiration_date) return '-'
+                    const expDate = new Date(row.expiration_date)
+                    const isExpired = expDate.getTime() < Date.now()
+                    return (
+                      <span
+                        style={{
+                          color: isExpired ? '#ef4444' : undefined,
+                        }}
+                      >
+                        {isExpired && (
+                          <Icon
+                            name="exclamation-triangle"
+                            tw="mr-1"
+                            size="12px"
+                          />
+                        )}
+                        {getDate(expDate.getTime() / 1000)}
+                      </span>
+                    )
+                  },
+                },
+                {
+                  label: 'RECEIVED',
+                  align: 'right',
+                  sortable: true,
+                  render: (row) =>
+                    getDate(new Date(row.message_timestamp).getTime() / 1000),
+                },
+                {
+                  label: '',
+                  align: 'left' as const,
+                  width: '100%',
+                  render: () => null,
+                },
+              ]}
+            />
+          </StyledScrollableTableContainer>
+        ) : (
+          <EmptyTablePlaceholder message="No balances with expiration dates." />
+        )}
+      </ToggleDashboard>
+    </section>
+  )
+}
+ExpiringBalances.displayName = 'ExpiringBalances'
+
+export default memo(ExpiringBalances)

--- a/src/components/pages/console/CreditsDashboardPage/ExpiringBalances/index.ts
+++ b/src/components/pages/console/CreditsDashboardPage/ExpiringBalances/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/console/CreditsDashboardPage/ExpiringBalances/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/ExpiringBalances/types.ts
@@ -1,0 +1,3 @@
+export type ExpiringBalancesProps = {
+  isConnected: boolean
+}

--- a/src/components/pages/console/CreditsDashboardPage/RecentPurchases/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/RecentPurchases/cmp.tsx
@@ -12,6 +12,11 @@ import { useReportIssueModal } from '@/components/modals/ReportIssueModal'
 import { StyledSectionHeader, StyledScrollableTableContainer } from '../styles'
 import { RecentPurchasesProps } from './types'
 
+const ellipseHash = (hash: string | null) => {
+  if (!hash) return '-'
+  return `${hash.slice(0, 6)}...${hash.slice(-4)}`
+}
+
 const EmptyTablePlaceholder = ({ message }: { message: string }) => (
   <NoisyContainer tw="text-center py-8">
     <Icon name="info-circle" color="base2" size="lg" tw="mb-3" />
@@ -102,33 +107,28 @@ const RecentPurchases = ({
                     },
                   },
                   {
-                    label: 'DATE',
-                    align: 'left',
+                    label: 'AMOUNT PAID',
+                    align: 'right',
                     sortable: true,
-                    render: (row) =>
-                      row.createdAt && getDate(row.createdAt / 1000),
+                    render: (row) => (
+                      <span style={{ color: '#ef4444' }}>
+                        {formatPaymentAmount(row.amount, row.asset)} {row.asset}
+                      </span>
+                    ),
                   },
                   {
-                    label: 'AMOUNT',
-                    align: 'left',
+                    label: 'CREDITS RECEIVED',
+                    align: 'right',
                     sortable: true,
-                    render: (row) => formatPaymentAmount(row.amount, row.asset),
-                  },
-                  {
-                    label: 'ASSET',
-                    align: 'left',
-                    sortable: true,
-                    render: (row) => row.asset,
-                  },
-                  {
-                    label: 'CREDITS',
-                    align: 'left',
-                    sortable: true,
-                    render: (row) => `~${formatCredits(row.credits)}`,
+                    render: (row) => (
+                      <span style={{ color: '#22c55e' }}>
+                        ~{formatCredits(row.credits)}
+                      </span>
+                    ),
                   },
                   {
                     label: 'TX',
-                    align: 'right',
+                    align: 'left',
                     render: (row) => {
                       const url = row.txHash
                         ? getETHExplorerURL({ hash: row.txHash })
@@ -139,15 +139,27 @@ const RecentPurchases = ({
                           target="_blank"
                           rel="noopener noreferrer"
                           onClick={(e) => e.stopPropagation()}
+                          tw="flex items-center gap-1"
+                          className="text-main0"
                         >
-                          <Icon
-                            name="external-link-square-alt"
-                            size="14px"
-                            color="purple4"
-                          />
+                          {ellipseHash(row.txHash)}
+                          <Icon name="external-link-square-alt" size="10px" />
                         </a>
                       ) : null
                     },
+                  },
+                  {
+                    label: 'DATE',
+                    align: 'right',
+                    sortable: true,
+                    render: (row) =>
+                      row.createdAt && getDate(row.createdAt / 1000),
+                  },
+                  {
+                    label: '',
+                    align: 'left' as const,
+                    width: '100%',
+                    render: () => null,
                   },
                 ]}
               />

--- a/src/components/pages/console/CreditsDashboardPage/RecentPurchases/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/RecentPurchases/cmp.tsx
@@ -145,7 +145,9 @@ const RecentPurchases = ({
                           {ellipseHash(row.txHash)}
                           <Icon name="external-link-square-alt" size="10px" />
                         </a>
-                      ) : null
+                      ) : (
+                        <span>-</span>
+                      )
                     },
                   },
                   {

--- a/src/components/pages/console/CreditsDashboardPage/RecentPurchases/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/RecentPurchases/cmp.tsx
@@ -1,0 +1,183 @@
+import React, { memo, useMemo, useState } from 'react'
+import 'twin.macro'
+import { Button, Icon, NoisyContainer, Spinner } from '@aleph-front/core'
+import { StyledTable } from '@/components/common/EntityTable/styles'
+import ToggleDashboard from '@/components/common/ToggleDashboard'
+import { SectionTitle } from '@/components/common/CompositeTitle'
+import PaymentHistoryPanel from '@/components/pages/console/DashboardPage/CreditsDashboard/PaymentHistoryPanel'
+import { PaymentStatus } from '@/domain/credit'
+import { getDate, formatPaymentAmount, formatCredits } from '@/helpers/utils'
+import { getETHExplorerURL } from '@/helpers/utils'
+import { useReportIssueModal } from '@/components/modals/ReportIssueModal'
+import { StyledSectionHeader, StyledScrollableTableContainer } from '../styles'
+import { RecentPurchasesProps } from './types'
+
+const EmptyTablePlaceholder = ({ message }: { message: string }) => (
+  <NoisyContainer tw="text-center py-8">
+    <Icon name="info-circle" color="base2" size="lg" tw="mb-3" />
+    <p className="text-base2 tp-body1">{message}</p>
+  </NoisyContainer>
+)
+
+const RecentPurchases = ({
+  isConnected,
+  purchaseHistory,
+  purchaseHistoryLoading,
+  handleOpenTopUpModal,
+  handleOpenPaymentStatusModal,
+}: RecentPurchasesProps) => {
+  const [open, setOpen] = useState(true)
+  const [isHistoryPanelOpen, setIsHistoryPanelOpen] = useState(false)
+  const { handleOpen: handleOpenReportIssue } = useReportIssueModal()
+
+  const recentHistory = useMemo(
+    () => purchaseHistory.slice(0, 5),
+    [purchaseHistory],
+  )
+
+  return (
+    <section tw="px-0 pb-6 pt-6 lg:pb-5">
+      <StyledSectionHeader>
+        <SectionTitle>
+          <span tw="flex items-center gap-3">
+            Purchases
+            {purchaseHistoryLoading && <Spinner size="1.5em" color="main0" />}
+          </span>
+        </SectionTitle>
+        <Button
+          variant="secondary"
+          kind="flat"
+          tw="bg-white!"
+          disabled={!isConnected}
+          onClick={() => handleOpenTopUpModal()}
+        >
+          Top Up Balance
+          <Icon name="credit-card" />
+        </Button>
+      </StyledSectionHeader>
+
+      <ToggleDashboard
+        open={open}
+        setOpen={setOpen}
+        toggleButton={{
+          children: (
+            <>
+              Show purchases <Icon name="shopping-cart" />
+            </>
+          ),
+          disabled: !isConnected,
+        }}
+      >
+        {recentHistory.length > 0 ? (
+          <>
+            <StyledScrollableTableContainer $maxHeight="28rem">
+              <StyledTable
+                clickableRows
+                rowKey={(row) => row.id}
+                data={recentHistory}
+                rowProps={(row) => ({
+                  onClick: () => handleOpenPaymentStatusModal(row),
+                })}
+                columns={[
+                  {
+                    label: 'STATUS',
+                    align: 'left',
+                    sortable: true,
+                    width: '1rem',
+                    render: (row) => {
+                      let color = 'warning'
+                      switch (row.status) {
+                        case PaymentStatus.Completed:
+                          color = 'success'
+                          break
+                        case PaymentStatus.Cancelled:
+                        case PaymentStatus.Failed:
+                          color = 'error'
+                          break
+                        default:
+                          color = 'warning'
+                          break
+                      }
+                      return <Icon name="circle" gradient={color} size="12px" />
+                    },
+                  },
+                  {
+                    label: 'DATE',
+                    align: 'left',
+                    sortable: true,
+                    render: (row) =>
+                      row.createdAt && getDate(row.createdAt / 1000),
+                  },
+                  {
+                    label: 'AMOUNT',
+                    align: 'left',
+                    sortable: true,
+                    render: (row) => formatPaymentAmount(row.amount, row.asset),
+                  },
+                  {
+                    label: 'ASSET',
+                    align: 'left',
+                    sortable: true,
+                    render: (row) => row.asset,
+                  },
+                  {
+                    label: 'CREDITS',
+                    align: 'left',
+                    sortable: true,
+                    render: (row) => `~${formatCredits(row.credits)}`,
+                  },
+                  {
+                    label: 'TX',
+                    align: 'right',
+                    render: (row) => {
+                      const url = row.txHash
+                        ? getETHExplorerURL({ hash: row.txHash })
+                        : undefined
+                      return url ? (
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Icon
+                            name="external-link-square-alt"
+                            size="14px"
+                            color="purple4"
+                          />
+                        </a>
+                      ) : null
+                    },
+                  },
+                ]}
+              />
+            </StyledScrollableTableContainer>
+            <Button
+              variant="textOnly"
+              size="sm"
+              tw="mt-4!"
+              onClick={() => setIsHistoryPanelOpen(true)}
+              disabled={!isConnected}
+            >
+              View Full History <Icon name="chevron-square-right" tw="ml-1" />
+            </Button>
+          </>
+        ) : (
+          <EmptyTablePlaceholder message="No purchases yet. Use the Top Up Balance button to add credits to your account." />
+        )}
+      </ToggleDashboard>
+
+      <PaymentHistoryPanel
+        isOpen={isHistoryPanelOpen}
+        onClose={() => setIsHistoryPanelOpen(false)}
+        payments={purchaseHistory}
+        loading={purchaseHistoryLoading}
+        onPaymentClick={handleOpenPaymentStatusModal}
+        onReportIssue={handleOpenReportIssue}
+      />
+    </section>
+  )
+}
+RecentPurchases.displayName = 'RecentPurchases'
+
+export default memo(RecentPurchases)

--- a/src/components/pages/console/CreditsDashboardPage/RecentPurchases/index.ts
+++ b/src/components/pages/console/CreditsDashboardPage/RecentPurchases/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/console/CreditsDashboardPage/RecentPurchases/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/RecentPurchases/types.ts
@@ -1,0 +1,9 @@
+import { CreditPaymentHistoryItem } from '@/domain/credit'
+
+export type RecentPurchasesProps = {
+  isConnected: boolean
+  purchaseHistory: CreditPaymentHistoryItem[]
+  purchaseHistoryLoading: boolean
+  handleOpenTopUpModal: (minimumBalance?: number) => void
+  handleOpenPaymentStatusModal: (payment: CreditPaymentHistoryItem) => void
+}

--- a/src/components/pages/console/CreditsDashboardPage/ServiceCosts/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/ServiceCosts/cmp.tsx
@@ -6,6 +6,7 @@ import ToggleDashboard from '@/components/common/ToggleDashboard'
 import { SectionTitle } from '@/components/common/CompositeTitle'
 import { useAccountEntities } from '@/hooks/common/useAccountEntities'
 import { formatCredits } from '@/helpers/utils'
+import { NAVIGATION_URLS } from '@/helpers/constants'
 import { StyledScrollableTableContainer } from '../styles'
 import { ServiceCostsProps } from './types'
 
@@ -27,36 +28,46 @@ const ServiceCosts = ({
     useAccountEntities()
 
   const entityMap = useMemo(() => {
-    const map = new Map<string, { name: string; type: string }>()
+    const map = new Map<
+      string,
+      { name: string; type: string; detailPath: string }
+    >()
 
     instances.forEach((e) =>
       map.set(e.id, {
         name: (e.metadata?.name as string) || e.id.slice(0, 8),
         type: 'Instance',
+        detailPath: NAVIGATION_URLS.console.computing.instances.detail(e.id),
       }),
     )
     gpuInstances.forEach((e) =>
       map.set(e.id, {
         name: (e.metadata?.name as string) || e.id.slice(0, 8),
         type: 'GPU',
+        detailPath: NAVIGATION_URLS.console.computing.gpus.detail(e.id),
       }),
     )
     confidentials.forEach((e) =>
       map.set(e.id, {
         name: (e.metadata?.name as string) || e.id.slice(0, 8),
         type: 'Confidential',
+        detailPath: NAVIGATION_URLS.console.computing.confidentials.detail(
+          e.id,
+        ),
       }),
     )
     volumes.forEach((e) =>
       map.set(e.id, {
         name: (e.metadata?.name as string) || e.id.slice(0, 8),
         type: 'Volume',
+        detailPath: NAVIGATION_URLS.console.storage.volumes.detail(e.id),
       }),
     )
     websites.forEach((e) =>
       map.set(e.id, {
         name: (e.metadata?.name as string) || e.id.slice(0, 8),
         type: 'Website',
+        detailPath: NAVIGATION_URLS.console.web3Hosting.website.detail(e.id),
       }),
     )
 
@@ -66,13 +77,17 @@ const ServiceCosts = ({
   const enrichedResources = useMemo(() => {
     return costsResources.map((r) => {
       const entity = entityMap.get(r.item_hash)
-      const costPerHour = parseFloat(r.cost_credit)
+      // cost_credit is in credits per second
+      const costPerSecond = parseFloat(r.cost_credit)
+      const costPerHour = costPerSecond * 3600
+      const costPerDay = costPerSecond * 3600 * 24
       return {
         ...r,
         resourceName: entity?.name || r.item_hash.slice(0, 12),
         resourceType: entity?.type || 'Unknown',
+        detailPath: entity?.detailPath,
         costPerHour,
-        costPerDay: costPerHour * 24,
+        costPerDay,
         isActive: !!entity,
       }
     })
@@ -106,21 +121,35 @@ const ServiceCosts = ({
                 data={enrichedResources}
                 columns={[
                   {
+                    label: 'STATUS',
+                    align: 'left',
+                    sortable: true,
+                    width: '1rem',
+                    render: (row) => (
+                      <Icon
+                        name="circle"
+                        gradient={row.isActive ? 'success' : 'warning'}
+                        size="10px"
+                      />
+                    ),
+                  },
+                  {
                     label: 'RESOURCE',
                     align: 'left',
                     sortable: true,
-                    render: (row) => (
-                      <a
-                        href={`https://explorer.aleph.im/address/ETH/${row.owner}/message/POST/${row.item_hash}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        tw="flex items-center gap-1"
-                        className="text-main0"
-                      >
-                        {row.resourceName}
-                        <Icon name="external-link-square-alt" size="10px" />
-                      </a>
-                    ),
+                    render: (row) =>
+                      row.detailPath ? (
+                        <a
+                          href={row.detailPath}
+                          tw="flex items-center gap-1"
+                          className="text-main0"
+                        >
+                          {row.resourceName}
+                          <Icon name="angle-right" size="10px" />
+                        </a>
+                      ) : (
+                        <span>{row.resourceName}</span>
+                      ),
                   },
                   {
                     label: 'TYPE',
@@ -129,34 +158,32 @@ const ServiceCosts = ({
                     render: (row) => row.resourceType,
                   },
                   {
-                    label: 'CONSUMED',
+                    label: 'TOTAL SPENT',
                     align: 'right',
                     sortable: true,
-                    render: (row) => formatCredits(row.consumed_credits),
+                    render: (row) => (
+                      <span style={{ color: '#ef4444' }}>
+                        {formatCredits(row.consumed_credits)}
+                      </span>
+                    ),
                   },
                   {
                     label: 'COST/HR',
                     align: 'right',
                     sortable: true,
-                    render: (row) => formatCredits(row.costPerHour * 1_000_000),
+                    render: (row) => formatCredits(row.costPerHour),
                   },
                   {
                     label: 'COST/DAY',
                     align: 'right',
                     sortable: true,
-                    render: (row) => formatCredits(row.costPerDay * 1_000_000),
+                    render: (row) => formatCredits(row.costPerDay),
                   },
                   {
-                    label: 'STATUS',
-                    align: 'center',
-                    sortable: true,
-                    render: (row) => (
-                      <Icon
-                        name="circle"
-                        gradient={row.isActive ? 'success' : 'warning'}
-                        size="10px"
-                      />
-                    ),
+                    label: '',
+                    align: 'left' as const,
+                    width: '100%',
+                    render: () => null,
                   },
                 ]}
               />

--- a/src/components/pages/console/CreditsDashboardPage/ServiceCosts/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/ServiceCosts/cmp.tsx
@@ -1,0 +1,174 @@
+import React, { memo, useMemo, useState } from 'react'
+import 'twin.macro'
+import { Icon, NoisyContainer, Spinner } from '@aleph-front/core'
+import { StyledTable } from '@/components/common/EntityTable/styles'
+import ToggleDashboard from '@/components/common/ToggleDashboard'
+import { SectionTitle } from '@/components/common/CompositeTitle'
+import { useAccountEntities } from '@/hooks/common/useAccountEntities'
+import { formatCredits } from '@/helpers/utils'
+import { StyledScrollableTableContainer } from '../styles'
+import { ServiceCostsProps } from './types'
+
+const EmptyTablePlaceholder = ({ message }: { message: string }) => (
+  <NoisyContainer tw="text-center py-8">
+    <Icon name="info-circle" color="base2" size="lg" tw="mb-3" />
+    <p className="text-base2 tp-body1">{message}</p>
+  </NoisyContainer>
+)
+
+const ServiceCosts = ({
+  isConnected,
+  costsResources,
+  costsLoading,
+}: ServiceCostsProps) => {
+  const [open, setOpen] = useState(true)
+
+  const { instances, gpuInstances, confidentials, volumes, websites } =
+    useAccountEntities()
+
+  const entityMap = useMemo(() => {
+    const map = new Map<string, { name: string; type: string }>()
+
+    instances.forEach((e) =>
+      map.set(e.id, {
+        name: (e.metadata?.name as string) || e.id.slice(0, 8),
+        type: 'Instance',
+      }),
+    )
+    gpuInstances.forEach((e) =>
+      map.set(e.id, {
+        name: (e.metadata?.name as string) || e.id.slice(0, 8),
+        type: 'GPU',
+      }),
+    )
+    confidentials.forEach((e) =>
+      map.set(e.id, {
+        name: (e.metadata?.name as string) || e.id.slice(0, 8),
+        type: 'Confidential',
+      }),
+    )
+    volumes.forEach((e) =>
+      map.set(e.id, {
+        name: (e.metadata?.name as string) || e.id.slice(0, 8),
+        type: 'Volume',
+      }),
+    )
+    websites.forEach((e) =>
+      map.set(e.id, {
+        name: (e.metadata?.name as string) || e.id.slice(0, 8),
+        type: 'Website',
+      }),
+    )
+
+    return map
+  }, [instances, gpuInstances, confidentials, volumes, websites])
+
+  const enrichedResources = useMemo(() => {
+    return costsResources.map((r) => {
+      const entity = entityMap.get(r.item_hash)
+      const costPerHour = parseFloat(r.cost_credit)
+      return {
+        ...r,
+        resourceName: entity?.name || r.item_hash.slice(0, 12),
+        resourceType: entity?.type || 'Unknown',
+        costPerHour,
+        costPerDay: costPerHour * 24,
+        isActive: !!entity,
+      }
+    })
+  }, [costsResources, entityMap])
+
+  return (
+    <section tw="px-0 pb-6 pt-6 lg:pb-5">
+      <SectionTitle>
+        <span tw="flex items-center gap-3">
+          Service Costs
+          {costsLoading && <Spinner size="1.5em" color="main0" />}
+        </span>
+      </SectionTitle>
+      <ToggleDashboard
+        open={open}
+        setOpen={setOpen}
+        toggleButton={{
+          children: (
+            <>
+              Show service costs <Icon name="server" />
+            </>
+          ),
+          disabled: !isConnected,
+        }}
+      >
+        <div>
+          {enrichedResources.length > 0 ? (
+            <StyledScrollableTableContainer $maxHeight="28rem">
+              <StyledTable
+                rowKey={(row) => row.item_hash}
+                data={enrichedResources}
+                columns={[
+                  {
+                    label: 'RESOURCE',
+                    align: 'left',
+                    sortable: true,
+                    render: (row) => (
+                      <a
+                        href={`https://explorer.aleph.im/address/ETH/${row.owner}/message/POST/${row.item_hash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        tw="flex items-center gap-1"
+                        className="text-main0"
+                      >
+                        {row.resourceName}
+                        <Icon name="external-link-square-alt" size="10px" />
+                      </a>
+                    ),
+                  },
+                  {
+                    label: 'TYPE',
+                    align: 'left',
+                    sortable: true,
+                    render: (row) => row.resourceType,
+                  },
+                  {
+                    label: 'CONSUMED',
+                    align: 'right',
+                    sortable: true,
+                    render: (row) => formatCredits(row.consumed_credits),
+                  },
+                  {
+                    label: 'COST/HR',
+                    align: 'right',
+                    sortable: true,
+                    render: (row) => formatCredits(row.costPerHour * 1_000_000),
+                  },
+                  {
+                    label: 'COST/DAY',
+                    align: 'right',
+                    sortable: true,
+                    render: (row) => formatCredits(row.costPerDay * 1_000_000),
+                  },
+                  {
+                    label: 'STATUS',
+                    align: 'center',
+                    sortable: true,
+                    render: (row) => (
+                      <Icon
+                        name="circle"
+                        gradient={row.isActive ? 'success' : 'warning'}
+                        size="10px"
+                      />
+                    ),
+                  },
+                ]}
+              />
+            </StyledScrollableTableContainer>
+          ) : (
+            <EmptyTablePlaceholder message="No active services consuming credits." />
+          )}
+        </div>
+      </ToggleDashboard>
+    </section>
+  )
+}
+ServiceCosts.displayName = 'ServiceCosts'
+
+export default memo(ServiceCosts)

--- a/src/components/pages/console/CreditsDashboardPage/ServiceCosts/index.ts
+++ b/src/components/pages/console/CreditsDashboardPage/ServiceCosts/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/console/CreditsDashboardPage/ServiceCosts/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/ServiceCosts/types.ts
@@ -1,0 +1,7 @@
+import { CostsResource } from '@/hooks/common/useServiceCosts'
+
+export type ServiceCostsProps = {
+  isConnected: boolean
+  costsResources: CostsResource[]
+  costsLoading: boolean
+}

--- a/src/components/pages/console/CreditsDashboardPage/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/cmp.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import 'twin.macro'
+import Head from 'next/head'
+import { CenteredContainer } from '@/components/common/CenteredContainer'
+import { useCreditsDashboardPage } from './hook'
+import CreditStatsHeader from './CreditStatsHeader'
+import RecentPurchases from './RecentPurchases'
+import CreditHistory from './CreditHistory'
+import ServiceCosts from './ServiceCosts'
+
+export default function CreditsDashboardPage() {
+  const {
+    isConnected,
+    accountCreditBalance,
+    costsSummary,
+    costsResources,
+    costsLoading,
+    purchaseHistory,
+    purchaseHistoryLoading,
+    handleOpenTopUpModal,
+    handleOpenPaymentStatusModal,
+    handleOpenTransferModal,
+  } = useCreditsDashboardPage()
+
+  return (
+    <>
+      <Head>
+        <title>Credits | Aleph Cloud</title>
+        <meta
+          name="description"
+          content="Manage your Aleph Cloud credits. View balance, track expenses, transfer credits, and monitor service costs."
+        />
+      </Head>
+      <CenteredContainer $variant="xl">
+        <CreditStatsHeader
+          isConnected={isConnected}
+          accountCreditBalance={accountCreditBalance}
+          costsSummary={costsSummary}
+          costsResources={costsResources}
+          costsLoading={costsLoading}
+        />
+
+        <RecentPurchases
+          isConnected={isConnected}
+          purchaseHistory={purchaseHistory}
+          purchaseHistoryLoading={purchaseHistoryLoading}
+          handleOpenTopUpModal={handleOpenTopUpModal}
+          handleOpenPaymentStatusModal={handleOpenPaymentStatusModal}
+        />
+
+        <CreditHistory
+          isConnected={isConnected}
+          handleOpenTransferModal={handleOpenTransferModal}
+        />
+
+        <ServiceCosts
+          isConnected={isConnected}
+          costsResources={costsResources}
+          costsLoading={costsLoading}
+        />
+      </CenteredContainer>
+    </>
+  )
+}

--- a/src/components/pages/console/CreditsDashboardPage/cmp.tsx
+++ b/src/components/pages/console/CreditsDashboardPage/cmp.tsx
@@ -7,11 +7,14 @@ import CreditStatsHeader from './CreditStatsHeader'
 import RecentPurchases from './RecentPurchases'
 import CreditHistory from './CreditHistory'
 import ServiceCosts from './ServiceCosts'
+import ExpiringBalances from './ExpiringBalances'
 
 export default function CreditsDashboardPage() {
   const {
     isConnected,
+    accountAddress,
     accountCreditBalance,
+    knownCrnHashes,
     costsSummary,
     costsResources,
     costsLoading,
@@ -50,6 +53,8 @@ export default function CreditsDashboardPage() {
 
         <CreditHistory
           isConnected={isConnected}
+          accountAddress={accountAddress}
+          knownCrnHashes={knownCrnHashes}
           handleOpenTransferModal={handleOpenTransferModal}
         />
 
@@ -58,6 +63,8 @@ export default function CreditsDashboardPage() {
           costsResources={costsResources}
           costsLoading={costsLoading}
         />
+
+        <ExpiringBalances isConnected={isConnected} />
       </CenteredContainer>
     </>
   )

--- a/src/components/pages/console/CreditsDashboardPage/hook.ts
+++ b/src/components/pages/console/CreditsDashboardPage/hook.ts
@@ -5,6 +5,7 @@ import { useTopUpCreditsModal } from '@/components/modals/TopUpCreditsModal/hook
 import { usePaymentStatusModal } from '@/components/modals/PaymentStatusModal/hook'
 import { useCreditTransferModal } from '@/components/modals/CreditTransferModal/hook'
 import { useServiceCosts } from '@/hooks/common/useServiceCosts'
+import { useAppState } from '@/contexts/appState'
 import { UseCreditsDashboardPageReturn } from './types'
 
 export function useCreditsDashboardPage(): UseCreditsDashboardPageReturn {
@@ -12,7 +13,19 @@ export function useCreditsDashboardPage(): UseCreditsDashboardPageReturn {
     triggerOnMount: false,
   })
 
+  const [state] = useAppState()
+  const crnNodes =
+    state.crns && 'entities' in state.crns ? state.crns.entities : undefined
+
   const isConnected = useMemo(() => !!account, [account])
+
+  const knownCrnHashes = useMemo(() => {
+    const set = new Set<string>()
+    if (crnNodes) {
+      crnNodes.forEach((node) => set.add(node.hash))
+    }
+    return set
+  }, [crnNodes])
 
   // Costs data
   const {
@@ -33,7 +46,9 @@ export function useCreditsDashboardPage(): UseCreditsDashboardPageReturn {
 
   return {
     isConnected,
+    accountAddress: account?.address,
     accountCreditBalance,
+    knownCrnHashes,
     costsSummary,
     costsResources,
     costsLoading,

--- a/src/components/pages/console/CreditsDashboardPage/hook.ts
+++ b/src/components/pages/console/CreditsDashboardPage/hook.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react'
+import { useConnection } from '@/hooks/common/useConnection'
+import { useCreditPaymentHistory } from '@/hooks/common/useCreditPaymentHistory'
+import { useTopUpCreditsModal } from '@/components/modals/TopUpCreditsModal/hook'
+import { usePaymentStatusModal } from '@/components/modals/PaymentStatusModal/hook'
+import { useCreditTransferModal } from '@/components/modals/CreditTransferModal/hook'
+import { useServiceCosts } from '@/hooks/common/useServiceCosts'
+import { UseCreditsDashboardPageReturn } from './types'
+
+export function useCreditsDashboardPage(): UseCreditsDashboardPageReturn {
+  const { account, creditBalance: accountCreditBalance } = useConnection({
+    triggerOnMount: false,
+  })
+
+  const isConnected = useMemo(() => !!account, [account])
+
+  // Costs data
+  const {
+    summary: costsSummary,
+    resources: costsResources,
+    loading: costsLoading,
+  } = useServiceCosts()
+
+  // Payment history (purchases)
+  const { history: purchaseHistory, loading: purchaseHistoryLoading } =
+    useCreditPaymentHistory()
+
+  // Modals
+  const { handleOpen: handleOpenTopUpModal } = useTopUpCreditsModal()
+  const { handleOpen: handleOpenPaymentStatusModal } = usePaymentStatusModal()
+
+  const { handleOpen: handleOpenTransferModal } = useCreditTransferModal()
+
+  return {
+    isConnected,
+    accountCreditBalance,
+    costsSummary,
+    costsResources,
+    costsLoading,
+    purchaseHistory,
+    purchaseHistoryLoading,
+    handleOpenTopUpModal,
+    handleOpenPaymentStatusModal,
+    handleOpenTransferModal,
+  }
+}

--- a/src/components/pages/console/CreditsDashboardPage/index.ts
+++ b/src/components/pages/console/CreditsDashboardPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cmp'

--- a/src/components/pages/console/CreditsDashboardPage/styles.ts
+++ b/src/components/pages/console/CreditsDashboardPage/styles.ts
@@ -1,0 +1,30 @@
+import styled, { css } from 'styled-components'
+import tw from 'twin.macro'
+
+export const StyledStatsRow = styled.div`
+  ${tw`flex flex-wrap gap-4 items-stretch`}
+`
+
+export const StyledSectionHeader = styled.div`
+  ${tw`flex items-center justify-between flex-wrap gap-3 mb-3`}
+  position: relative;
+  z-index: 2;
+`
+
+export const StyledScrollableTableContainer = styled.div<{
+  $maxHeight?: string
+}>`
+  ${({ $maxHeight = '28rem' }) => css`
+    max-height: ${$maxHeight};
+    overflow-y: auto;
+    overflow-x: auto;
+
+    table {
+      thead {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+    }
+  `}
+`

--- a/src/components/pages/console/CreditsDashboardPage/styles.ts
+++ b/src/components/pages/console/CreditsDashboardPage/styles.ts
@@ -6,9 +6,13 @@ export const StyledStatsRow = styled.div`
 `
 
 export const StyledSectionHeader = styled.div`
-  ${tw`flex items-center justify-between flex-wrap gap-3 mb-3`}
+  ${tw`flex items-start justify-between flex-wrap gap-3 mb-3`}
   position: relative;
   z-index: 2;
+
+  h2 {
+    margin: 0;
+  }
 `
 
 export const StyledScrollableTableContainer = styled.div<{

--- a/src/components/pages/console/CreditsDashboardPage/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/types.ts
@@ -1,0 +1,22 @@
+import { CostsSummary, CostsResource } from '@/hooks/common/useServiceCosts'
+import { CreditPaymentHistoryItem } from '@/domain/credit'
+
+export type UseCreditsDashboardPageReturn = {
+  // Connection
+  isConnected: boolean
+  accountCreditBalance?: number
+
+  // Costs
+  costsSummary?: CostsSummary
+  costsResources: CostsResource[]
+  costsLoading: boolean
+
+  // Payment history (purchases)
+  purchaseHistory: CreditPaymentHistoryItem[]
+  purchaseHistoryLoading: boolean
+
+  // Modals
+  handleOpenTopUpModal: (minimumBalance?: number) => void
+  handleOpenPaymentStatusModal: (payment: CreditPaymentHistoryItem) => void
+  handleOpenTransferModal: () => void
+}

--- a/src/components/pages/console/CreditsDashboardPage/types.ts
+++ b/src/components/pages/console/CreditsDashboardPage/types.ts
@@ -4,7 +4,9 @@ import { CreditPaymentHistoryItem } from '@/domain/credit'
 export type UseCreditsDashboardPageReturn = {
   // Connection
   isConnected: boolean
+  accountAddress?: string
   accountCreditBalance?: number
+  knownCrnHashes: Set<string>
 
   // Costs
   costsSummary?: CostsSummary

--- a/src/components/pages/console/DashboardPage/CreditsDashboard/cmp.tsx
+++ b/src/components/pages/console/DashboardPage/CreditsDashboard/cmp.tsx
@@ -130,7 +130,17 @@ export default function CreditsDashboard() {
                   History <Icon name="chevron-square-right" tw="ml-1" />
                 </Button>
               </div>
-              <div tw="overflow-x-auto">
+              <div
+                tw="overflow-x-auto"
+                style={{ maxHeight: '28rem', overflowY: 'auto' }}
+                css={`
+                  table thead {
+                    position: sticky;
+                    top: 0;
+                    z-index: 1;
+                  }
+                `}
+              >
                 <StyledTable
                   // borderType="none"
                   // rowNoise

--- a/src/components/pages/console/DashboardPage/CreditsDashboard/cmp.tsx
+++ b/src/components/pages/console/DashboardPage/CreditsDashboard/cmp.tsx
@@ -23,12 +23,12 @@ import tw from 'twin.macro'
 
 export default function CreditsDashboard() {
   const {
-    runRateDays,
+    runRate,
     creditsDashboardOpen,
     setCreditsDashboardOpen,
     isConnected,
     accountCreditBalance,
-    isCalculatingCosts,
+    costsLoading,
     history,
     historyLoading,
     recentHistory,
@@ -84,16 +84,42 @@ export default function CreditsDashboard() {
                     className="bg-base1"
                     tw="flex flex-col items-start justify-between px-3 py-2 min-w-[6.875rem] min-h-[3.8125rem]"
                   >
-                    <p className="tp-info text-base2">RUN-RATE</p>
-                    {isCalculatingCosts ? (
+                    <p className="tp-info text-base2">ESTIMATED RUN TIME</p>
+                    {costsLoading ? (
                       <Skeleton width="4rem" height="1.5rem" />
-                    ) : (
-                      <div tw="flex items-end gap-0.5">
-                        <p className="text-main0 tp-h7">{runRateDays || '∞'}</p>
-                        <p className="text-main0 tp-info" tw="mb-1 ml-1">
-                          {runRateDays === 1 ? 'DAY' : 'DAYS'}
-                        </p>
+                    ) : runRate ? (
+                      <div tw="flex items-end gap-1.5">
+                        {runRate.years > 0 && (
+                          <div tw="flex items-end gap-0.5">
+                            <p className="text-main0 tp-h7">{runRate.years}</p>
+                            <p className="text-main0 tp-info" tw="mb-1">
+                              {runRate.years === 1 ? 'Y' : 'Y'}
+                            </p>
+                          </div>
+                        )}
+                        {(runRate.years > 0 || runRate.months > 0) && (
+                          <div tw="flex items-end gap-0.5">
+                            <p className="text-main0 tp-h7">{runRate.months}</p>
+                            <p className="text-main0 tp-info" tw="mb-1">
+                              M
+                            </p>
+                          </div>
+                        )}
+                        <div tw="flex items-end gap-0.5">
+                          <p className="text-main0 tp-h7">{runRate.days}</p>
+                          <p className="text-main0 tp-info" tw="mb-1">
+                            D
+                          </p>
+                        </div>
+                        <div tw="flex items-end gap-0.5">
+                          <p className="text-main0 tp-h7">{runRate.hours}</p>
+                          <p className="text-main0 tp-info" tw="mb-1">
+                            H
+                          </p>
+                        </div>
                       </div>
+                    ) : (
+                      <p className="text-main0 tp-h7">∞</p>
                     )}
                   </div>
                 </div>

--- a/src/components/pages/console/DashboardPage/CreditsDashboard/hook.ts
+++ b/src/components/pages/console/DashboardPage/CreditsDashboard/hook.ts
@@ -1,19 +1,6 @@
-import {
-  useEffect,
-  useState,
-  useMemo,
-  Dispatch,
-  SetStateAction,
-  useCallback,
-} from 'react'
-import { useAccountEntities } from '@/hooks/common/useAccountEntities'
-import { useInstanceManager } from '@/hooks/common/useManager/useInstanceManager'
-import { useGpuInstanceManager } from '@/hooks/common/useManager/useGpuInstanceManager'
-import { useConfidentialManager } from '@/hooks/common/useManager/useConfidentialManager'
-import { PaymentMethod } from '@/helpers/constants'
-import { useRequestExecutableStatus } from '@/hooks/common/useRequestEntity/useRequestExecutableStatus'
-import { PaymentType } from '@aleph-sdk/message'
+import { useEffect, useState, useMemo, Dispatch, SetStateAction } from 'react'
 import { useConnection } from '@/hooks/common/useConnection'
+import { useServiceCosts } from '@/hooks/common/useServiceCosts'
 import { useCreditPaymentHistory } from '@/hooks/common/useCreditPaymentHistory'
 import { useTopUpCreditsModal } from '@/components/modals/TopUpCreditsModal/hook'
 import { usePaymentStatusModal } from '@/components/modals/PaymentStatusModal/hook'
@@ -21,9 +8,15 @@ import { CreditPaymentHistoryItem } from '@/domain/credit'
 
 export type UseCreditsDashboardReturn = {
   // Balance & costs
-  totalCostPerHour: number
   runRateDays: number
-  isCalculatingCosts: boolean
+  runRate: {
+    totalHours: number
+    years: number
+    months: number
+    days: number
+    hours: number
+  } | null
+  costsLoading: boolean
   accountCreditBalance?: number
 
   // Connection
@@ -50,9 +43,7 @@ export type UseCreditsDashboardReturn = {
 }
 
 export function useCreditsDashboard(): UseCreditsDashboardReturn {
-  const [totalCostPerHour, setTotalCostPerHour] = useState(0)
   const [creditsDashboardOpen, setCreditsDashboardOpen] = useState(false)
-  const [isCalculatingCosts, setIsCalculatingCosts] = useState(true)
 
   const { account, creditBalance: accountCreditBalance } = useConnection({
     triggerOnMount: false,
@@ -73,150 +64,29 @@ export function useCreditsDashboard(): UseCreditsDashboardReturn {
   // Show only latest 5 payments in dashboard
   const recentHistory = useMemo(() => history.slice(0, 5), [history])
 
-  // Get all entities
-  const { instances, gpuInstances, confidentials } = useAccountEntities()
+  // Use /costs API for run rate calculation
+  const { summary: costsSummary, loading: costsLoading } = useServiceCosts()
 
-  const creditInstances = useMemo(
-    () =>
-      instances.filter(
-        (instance) => instance.payment?.type === PaymentType.credit,
-      ),
-    [instances],
-  )
-  const creditGpuInstances = useMemo(
-    () =>
-      gpuInstances.filter(
-        (gpuInstance) => gpuInstance.payment?.type === PaymentType.credit,
-      ),
-    [gpuInstances],
-  )
-  const creditConfidentials = useMemo(
-    () =>
-      confidentials.filter(
-        (confidential) => confidential.payment?.type === PaymentType.credit,
-      ),
-    [confidentials],
-  )
-
-  // Get managers
-  const instanceManager = useInstanceManager()
-  const gpuInstanceManager = useGpuInstanceManager()
-  const confidentialManager = useConfidentialManager()
-
-  // Get status for running entities
-  const { status: creditInstancesStatus } = useRequestExecutableStatus({
-    entities: creditInstances,
-  })
-  const { status: creditGpuInstancesStatus } = useRequestExecutableStatus({
-    entities: creditGpuInstances,
-  })
-  const { status: creditConfidentialsStatus } = useRequestExecutableStatus({
-    entities: creditConfidentials,
-    managerHook: useConfidentialManager,
-  })
-
-  // Helper function to check if entity is running
-  const isRunning = useCallback((entityId: string, status?: any) => {
-    const statusData = status?.data
-
-    return (
-      statusData &&
-      (statusData.vm_ipv6 || statusData.ipv6Parsed || statusData.ipv6)
-    )
-  }, [])
-
-  // Helper function to calculate cost for a computing entity
-  const calculateComputingEntityCost = useCallback(
-    async (entityId: string, entityStatus: any, manager: any) => {
-      try {
-        if (isRunning(entityId, entityStatus) && manager) {
-          const cost = await manager.getTotalCostByHash(
-            PaymentMethod.Credit,
-            entityId,
-          )
-
-          return cost
-        } else {
-          return 0
-        }
-      } catch (err) {
-        console.error('Error calculating entity cost:', err)
-        return 0
-      }
-    },
-    [isRunning],
-  )
-
-  // Calculate total cost per hour
-  useEffect(() => {
-    async function calculateTotalCost() {
-      setIsCalculatingCosts(true)
-
-      try {
-        let total = 0
-
-        // Calculate costs for regular credit instances
-        for (const instance of creditInstances) {
-          total += await calculateComputingEntityCost(
-            instance.id,
-            creditInstancesStatus[instance.id],
-            instanceManager,
-          )
-        }
-
-        // Calculate costs for credit GPU instances
-        for (const gpuInstance of creditGpuInstances) {
-          total += await calculateComputingEntityCost(
-            gpuInstance.id,
-            creditGpuInstancesStatus[gpuInstance.id],
-            gpuInstanceManager,
-          )
-        }
-
-        // Calculate costs for credit confidential instances
-        for (const confidential of creditConfidentials) {
-          total += await calculateComputingEntityCost(
-            confidential.id,
-            creditConfidentialsStatus[confidential.id],
-            confidentialManager,
-          )
-        }
-
-        setTotalCostPerHour(total)
-      } catch (err) {
-        console.error('Error calculating total cost:', err)
-      } finally {
-        setIsCalculatingCosts(false)
-      }
+  const runRate = useMemo(() => {
+    if (!accountCreditBalance || accountCreditBalance <= 0 || !costsSummary) {
+      return null
     }
 
-    calculateTotalCost()
-  }, [
-    calculateComputingEntityCost,
-    confidentialManager,
-    creditConfidentials,
-    creditConfidentialsStatus,
-    creditGpuInstances,
-    creditGpuInstancesStatus,
-    creditInstances,
-    creditInstancesStatus,
-    gpuInstanceManager,
-    instanceManager,
-  ])
+    // total_cost_credit is credits per second
+    const perSecond = parseFloat(costsSummary.total_cost_credit)
+    if (perSecond <= 0) return null
 
-  // Calculate run rate days
-  const runRateDays = useMemo(() => {
-    if (
-      !accountCreditBalance ||
-      accountCreditBalance <= 0 ||
-      totalCostPerHour <= 0
-    ) {
-      return 0
-    }
+    const costPerHour = perSecond * 3600
+    const totalHours = accountCreditBalance / costPerHour
+    const years = Math.floor(totalHours / (24 * 365))
+    const months = Math.floor((totalHours % (24 * 365)) / (24 * 30))
+    const days = Math.floor((totalHours % (24 * 30)) / 24)
+    const hours = Math.floor(totalHours % 24)
 
-    const totalCostPerDay = totalCostPerHour * 24
-    return Math.floor(accountCreditBalance / totalCostPerDay)
-  }, [accountCreditBalance, totalCostPerHour])
+    return { totalHours, years, months, days, hours }
+  }, [accountCreditBalance, costsSummary])
+
+  const runRateDays = runRate ? Math.floor(runRate.totalHours / 24) : 0
 
   // Handle dashboard open/close based on connection
   useEffect(() => {
@@ -227,9 +97,9 @@ export function useCreditsDashboard(): UseCreditsDashboardReturn {
 
   return {
     // Balance & costs
-    totalCostPerHour,
     runRateDays,
-    isCalculatingCosts,
+    runRate,
+    costsLoading,
     accountCreditBalance,
 
     // Connection

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -326,6 +326,9 @@ export const NAVIGATION_URLS = {
         detail: (id: string) => `/console/storage/volume/${id}`,
       },
     },
+    credits: {
+      home: '/console/credits',
+    },
   },
   account: {
     home: '/account',

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -90,6 +90,7 @@ type CheckoutAddStepType =
   | 'allocate'
   | 'portForwarding'
   | 'creditTransaction'
+  | 'creditTransfer'
   | 'permissions'
 
 type CheckoutDelStepType =

--- a/src/helpers/schemas/credit.ts
+++ b/src/helpers/schemas/credit.ts
@@ -49,6 +49,46 @@ export type CreditEstimationRequest = {
   creditAmount: number
 }
 
+// Credit transfer schema
+export const creditTransferRecipientSchema = z.object({
+  address: z
+    .string()
+    .min(1, 'Address is required')
+    .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address'),
+  amount: z.coerce
+    .number({
+      required_error: 'Amount is required',
+      invalid_type_error: 'Amount must be a number',
+    })
+    .positive('Amount must be greater than $0'),
+  expiration: z.string().optional(),
+})
+
+export const creditTransferSchema = z
+  .object({
+    recipients: z
+      .array(creditTransferRecipientSchema)
+      .min(1, 'At least one recipient is required'),
+  })
+  .refine(
+    (data) => {
+      const addresses = data.recipients
+        .map((r) => r.address.toLowerCase())
+        .filter(Boolean)
+      return new Set(addresses).size === addresses.length
+    },
+    {
+      message:
+        'Duplicate recipient addresses are not allowed in a single transfer',
+      path: ['recipients'],
+    },
+  )
+
+export type CreditTransferFormData = z.infer<typeof creditTransferSchema>
+export type CreditTransferRecipient = z.infer<
+  typeof creditTransferRecipientSchema
+>
+
 export type CreditEstimationResponse = {
   tokenAmount: string
   tokenAmountInUnits: number // Token amount converted from wei to whole units

--- a/src/hooks/common/useBreadcrumbNames.ts
+++ b/src/hooks/common/useBreadcrumbNames.ts
@@ -31,6 +31,7 @@ const defaultNames = {
   [NAVIGATION_URLS.console.web3Hosting.website.home]: 'WEB3 HOSTING / WEBSITES',
   [`${NAVIGATION_URLS.console.web3Hosting.website.home}/[hash]`]: '-',
   [NAVIGATION_URLS.console.web3Hosting.website.new]: 'SETUP NEW WEBSITE',
+  [NAVIGATION_URLS.console.credits.home]: 'CREDITS',
   [NAVIGATION_URLS.account.home]: 'ACCOUNT',
   [NAVIGATION_URLS.account.earn.home]: 'EARN',
   [NAVIGATION_URLS.account.earn.staking]: 'STAKING',

--- a/src/hooks/common/useCreditHistory.ts
+++ b/src/hooks/common/useCreditHistory.ts
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+import { getApiServer } from '@/helpers/server'
+
+export type CreditHistoryEntry = {
+  amount: number
+  price: string | null
+  bonus_amount: number | null
+  tx_hash: string | null
+  token: string | null
+  chain: string | null
+  provider: string
+  origin: string
+  origin_ref: string | null
+  payment_method: string
+  credit_ref: string
+  credit_index: number
+  expiration_date: string | null
+  message_timestamp: string
+}
+
+export type CreditHistoryFilters = {
+  payment_method?: string
+  search?: string
+}
+
+export type CreditHistorySortField =
+  | 'message_timestamp'
+  | 'amount'
+  | 'payment_method'
+  | 'expiration_date'
+  | 'origin'
+
+export type CreditHistorySort = {
+  field: CreditHistorySortField
+  direction: 'asc' | 'desc'
+}
+
+export type UseCreditHistoryReturn = {
+  entries: CreditHistoryEntry[]
+  filteredEntries: CreditHistoryEntry[]
+  loading: boolean
+  error?: Error
+  page: number
+  setPage: (page: number) => void
+  totalPages: number
+  totalEntries: number
+  filters: CreditHistoryFilters
+  setFilters: (filters: CreditHistoryFilters) => void
+  sort: CreditHistorySort
+  setSort: (sort: CreditHistorySort) => void
+  refetch: () => void
+}
+
+const PAGE_SIZE = 50
+
+export function useCreditHistory(): UseCreditHistoryReturn {
+  const [state] = useAppState()
+  const { account } = state.connection
+
+  const [entries, setEntries] = useState<CreditHistoryEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | undefined>()
+  const [page, setPage] = useState(1)
+  const [totalEntries, setTotalEntries] = useState(0)
+  const [filters, setFilters] = useState<CreditHistoryFilters>({})
+  const [sort, setSort] = useState<CreditHistorySort>({
+    field: 'message_timestamp',
+    direction: 'desc',
+  })
+
+  const fetchHistory = useCallback(async () => {
+    if (!account?.address) return
+
+    setLoading(true)
+    setError(undefined)
+
+    try {
+      const apiServer = getApiServer()
+      const params = new URLSearchParams({
+        pagination: String(PAGE_SIZE),
+        page: String(page),
+      })
+
+      if (filters.payment_method) {
+        params.set('payment_method', filters.payment_method)
+      }
+
+      const url = `${apiServer}/api/v0/addresses/${account.address}/credit_history?${params}`
+
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`)
+      }
+
+      const data = await response.json()
+      setEntries(data.credit_history || [])
+      setTotalEntries(data.pagination_total || 0)
+    } catch (err) {
+      console.error('Error fetching credit history:', err)
+      setError(err as Error)
+    } finally {
+      setLoading(false)
+    }
+  }, [account?.address, page, filters.payment_method])
+
+  useEffect(() => {
+    fetchHistory()
+  }, [fetchHistory])
+
+  // Client-side search across all fields
+  const searchFilteredEntries = useMemo(() => {
+    if (!filters.search) return entries
+
+    const query = filters.search.toLowerCase()
+    return entries.filter((entry) => {
+      const fields = [
+        String(entry.amount),
+        entry.origin,
+        entry.origin_ref,
+        entry.tx_hash,
+        entry.credit_ref,
+        entry.payment_method,
+        entry.provider,
+        entry.chain,
+        entry.token,
+        entry.message_timestamp,
+        entry.price,
+        entry.expiration_date,
+      ]
+      return fields.some((f) => f && f.toLowerCase().includes(query))
+    })
+  }, [entries, filters.search])
+
+  // Client-side sorting
+  const filteredEntries = useMemo(() => {
+    const sorted = [...searchFilteredEntries]
+
+    sorted.sort((a, b) => {
+      const dir = sort.direction === 'asc' ? 1 : -1
+
+      switch (sort.field) {
+        case 'message_timestamp':
+          return (
+            dir *
+            (new Date(a.message_timestamp).getTime() -
+              new Date(b.message_timestamp).getTime())
+          )
+        case 'amount':
+          return dir * (a.amount - b.amount)
+        case 'payment_method':
+          return dir * a.payment_method.localeCompare(b.payment_method)
+        case 'expiration_date': {
+          const aDate = a.expiration_date
+            ? new Date(a.expiration_date).getTime()
+            : 0
+          const bDate = b.expiration_date
+            ? new Date(b.expiration_date).getTime()
+            : 0
+          return dir * (aDate - bDate)
+        }
+        case 'origin':
+          return dir * a.origin.localeCompare(b.origin)
+        default:
+          return 0
+      }
+    })
+
+    return sorted
+  }, [searchFilteredEntries, sort])
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(totalEntries / PAGE_SIZE)),
+    [totalEntries],
+  )
+
+  return {
+    entries,
+    filteredEntries,
+    loading,
+    error,
+    page,
+    setPage,
+    totalPages,
+    totalEntries,
+    filters,
+    setFilters,
+    sort,
+    setSort,
+    refetch: fetchHistory,
+  }
+}

--- a/src/hooks/common/useCreditHistory.ts
+++ b/src/hooks/common/useCreditHistory.ts
@@ -58,6 +58,7 @@ const PAGE_SIZE = 50
 export function useCreditHistory(): UseCreditHistoryReturn {
   const [state] = useAppState()
   const { account } = state.connection
+  const { creditDataRefreshTrigger } = state.ui
 
   const [entries, setEntries] = useState<CreditHistoryEntry[]>([])
   const [loading, setLoading] = useState(false)
@@ -115,7 +116,7 @@ export function useCreditHistory(): UseCreditHistoryReturn {
 
   useEffect(() => {
     fetchHistory()
-  }, [fetchHistory])
+  }, [fetchHistory, creditDataRefreshTrigger])
 
   // Client-side search across all fields
   const searchFilteredEntries = useMemo(() => {

--- a/src/hooks/common/useCreditHistory.ts
+++ b/src/hooks/common/useCreditHistory.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAppState } from '@/contexts/appState'
 import { getApiServer } from '@/helpers/server'
+import { formatCredits } from '@/helpers/utils'
 
 export type CreditHistoryEntry = {
   amount: number
@@ -89,6 +90,14 @@ export function useCreditHistory(): UseCreditHistoryReturn {
       const url = `${apiServer}/api/v0/addresses/${account.address}/credit_history?${params}`
 
       const response = await fetch(url)
+
+      // 404 means no entries for this filter - clear data
+      if (response.status === 404) {
+        setEntries([])
+        setTotalEntries(0)
+        return
+      }
+
       if (!response.ok) {
         throw new Error(`API error: ${response.status}`)
       }
@@ -116,6 +125,7 @@ export function useCreditHistory(): UseCreditHistoryReturn {
     return entries.filter((entry) => {
       const fields = [
         String(entry.amount),
+        formatCredits(entry.amount),
         entry.origin,
         entry.origin_ref,
         entry.tx_hash,
@@ -127,6 +137,7 @@ export function useCreditHistory(): UseCreditHistoryReturn {
         entry.message_timestamp,
         entry.price,
         entry.expiration_date,
+        entry.bonus_amount != null ? String(entry.bonus_amount) : null,
       ]
       return fields.some((f) => f && f.toLowerCase().includes(query))
     })

--- a/src/hooks/common/useCreditPaymentHistory.ts
+++ b/src/hooks/common/useCreditPaymentHistory.ts
@@ -15,6 +15,7 @@ export function useCreditPaymentHistory(): UseCreditPaymentHistoryReturn {
   const creditManager = useCreditManager()
   const [state] = useAppState()
   const { account } = state.connection
+  const { creditDataRefreshTrigger } = state.ui
 
   const fetchPayments = useCallback(async (): Promise<
     CreditPaymentHistoryItem[]
@@ -38,7 +39,7 @@ export function useCreditPaymentHistory(): UseCreditPaymentHistoryReturn {
     onSuccess: () => null,
     flushData: false,
     triggerOnMount: !!account,
-    triggerDeps: [creditManager, account],
+    triggerDeps: [creditManager, account, creditDataRefreshTrigger],
     cacheStrategy: 'overwrite',
   })
 

--- a/src/hooks/common/useCreditTransfer.ts
+++ b/src/hooks/common/useCreditTransfer.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+import { AuthenticatedAlephHttpClient } from '@aleph-sdk/client'
+
+export type CreditTransferRecipient = {
+  address: string
+  amount: number
+  expiration?: number
+}
+
+export type UseCreditTransferReturn = {
+  transfer: (recipients: CreditTransferRecipient[]) => Promise<string>
+  loading: boolean
+  error?: Error
+  lastItemHash?: string
+}
+
+const ALEPH_CREDIT_CHANNEL = 'ALEPH_CREDIT'
+const ALEPH_CREDIT_TRANSFER_TYPE = 'aleph_credit_transfer'
+
+export function useCreditTransfer(): UseCreditTransferReturn {
+  const [state] = useAppState()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | undefined>()
+  const [lastItemHash, setLastItemHash] = useState<string | undefined>()
+
+  const transfer = useCallback(
+    async (recipients: CreditTransferRecipient[]): Promise<string> => {
+      const { account } = state.connection
+
+      if (!account) {
+        throw new Error('Account is required for credit transfers')
+      }
+
+      const sdkClient = new AuthenticatedAlephHttpClient(account)
+
+      setLoading(true)
+      setError(undefined)
+
+      try {
+        const credits = recipients.map((r) => ({
+          address: r.address,
+          amount: r.amount,
+          ...(r.expiration && { expiration: r.expiration }),
+        }))
+
+        const res = await sdkClient.createPost({
+          postType: ALEPH_CREDIT_TRANSFER_TYPE,
+          channel: ALEPH_CREDIT_CHANNEL,
+          content: {
+            transfer: {
+              credits,
+            },
+          },
+        })
+
+        const itemHash = res.item_hash
+        setLastItemHash(itemHash)
+        return itemHash
+      } catch (err) {
+        const error = err as Error
+        setError(error)
+        throw error
+      } finally {
+        setLoading(false)
+      }
+    },
+    [state.connection],
+  )
+
+  return {
+    transfer,
+    loading,
+    error,
+    lastItemHash,
+  }
+}

--- a/src/hooks/common/useGlobalPaymentTracking.ts
+++ b/src/hooks/common/useGlobalPaymentTracking.ts
@@ -3,9 +3,12 @@ import { useNotification } from '@aleph-front/core'
 import { usePaymentTracking } from '@/hooks/common/usePaymentTracking'
 import { CreditPaymentHistoryItem } from '@/domain/credit'
 import { formatCredits } from '@/helpers/utils'
+import { useAppState } from '@/contexts/appState'
+import { triggerCreditDataRefresh } from '@/store/ui'
 
 export function useGlobalPaymentTracking() {
   const noti = useNotification()
+  const [, dispatch] = useAppState()
 
   const handlePaymentCompleted = useCallback(
     (payment: CreditPaymentHistoryItem) => {
@@ -14,8 +17,11 @@ export function useGlobalPaymentTracking() {
         title: 'Purchase complete',
         text: `Your balance has been credited with ~${formatCredits(payment.credits)}.`,
       })
+
+      // Refresh all credit-related data (history, costs, etc.)
+      dispatch(triggerCreditDataRefresh())
     },
-    [noti],
+    [noti, dispatch],
   )
 
   return usePaymentTracking({ onPaymentCompleted: handlePaymentCompleted })

--- a/src/hooks/common/usePaymentMethod.ts
+++ b/src/hooks/common/usePaymentMethod.ts
@@ -31,6 +31,7 @@ export function usePaymentMethod({
 }: UsePaymentMethodProps = {}): UsePaymentMethodReturn {
   const [state, dispatch] = useAppState()
   const { paymentMethod, account } = state.connection
+  const { creditDataRefreshTrigger } = state.ui
   const router = useRouter()
   const { pathname } = router
 
@@ -79,6 +80,12 @@ export function usePaymentMethod({
     if (!account) return
     fetchBalance()
   }, [account, paymentMethod, fetchBalance, triggerOnMount])
+
+  // Refetch balance when credit data refresh is triggered
+  useEffect(() => {
+    if (!creditDataRefreshTrigger || !account) return
+    fetchBalance()
+  }, [creditDataRefreshTrigger, account, fetchBalance])
 
   return {
     paymentMethod,

--- a/src/hooks/common/useRoutes.ts
+++ b/src/hooks/common/useRoutes.ts
@@ -70,6 +70,11 @@ export function useRoutes(): UseRoutesReturn {
                 icon: 'dashboard',
               },
               {
+                name: 'Credits',
+                href: NAVIGATION_URLS.console.credits.home,
+                icon: 'credit-card',
+              },
+              {
                 name: 'Permissions',
                 href: NAVIGATION_URLS.console.permissions.home,
                 icon: 'permissions',

--- a/src/hooks/common/useServiceCosts.ts
+++ b/src/hooks/common/useServiceCosts.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useAppState } from '@/contexts/appState'
+import { getApiServer } from '@/helpers/server'
+
+export type CostsSummary = {
+  total_consumed_credits: number
+  total_cost_hold: string
+  total_cost_stream: string
+  total_cost_credit: string
+  resource_count: number
+}
+
+export type CostsResource = {
+  item_hash: string
+  owner: string
+  payment_type: string
+  consumed_credits: number
+  cost_hold: string
+  cost_stream: string
+  cost_credit: string
+  detail: Record<string, unknown> | null
+}
+
+export type CostsResponse = {
+  summary: CostsSummary
+  filters: Record<string, unknown>
+  resources: CostsResource[] | null
+  pagination_page: number | null
+  pagination_total: number | null
+  pagination_per_page: number | null
+  pagination_item: string | null
+}
+
+export type UseServiceCostsReturn = {
+  summary?: CostsSummary
+  resources: CostsResource[]
+  loading: boolean
+  error?: Error
+  refetch: () => void
+}
+
+export function useServiceCosts(): UseServiceCostsReturn {
+  const [state] = useAppState()
+  const { account } = state.connection
+
+  const [summary, setSummary] = useState<CostsSummary | undefined>()
+  const [resources, setResources] = useState<CostsResource[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | undefined>()
+
+  const fetchCosts = useCallback(async () => {
+    if (!account?.address) return
+
+    setLoading(true)
+    setError(undefined)
+
+    try {
+      const apiServer = getApiServer()
+      const url = `${apiServer}/api/v0/costs?address=${account.address}&include_details=1&include_size=true`
+
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`)
+      }
+
+      const data: CostsResponse = await response.json()
+      setSummary(data.summary)
+      setResources(data.resources || [])
+    } catch (err) {
+      console.error('Error fetching service costs:', err)
+      setError(err as Error)
+    } finally {
+      setLoading(false)
+    }
+  }, [account?.address])
+
+  useEffect(() => {
+    fetchCosts()
+  }, [fetchCosts])
+
+  return {
+    summary,
+    resources,
+    loading,
+    error,
+    refetch: fetchCosts,
+  }
+}

--- a/src/hooks/common/useServiceCosts.ts
+++ b/src/hooks/common/useServiceCosts.ts
@@ -42,6 +42,7 @@ export type UseServiceCostsReturn = {
 export function useServiceCosts(): UseServiceCostsReturn {
   const [state] = useAppState()
   const { account } = state.connection
+  const { creditDataRefreshTrigger } = state.ui
 
   const [summary, setSummary] = useState<CostsSummary | undefined>()
   const [resources, setResources] = useState<CostsResource[]>([])
@@ -76,7 +77,7 @@ export function useServiceCosts(): UseServiceCostsReturn {
 
   useEffect(() => {
     fetchCosts()
-  }, [fetchCosts])
+  }, [fetchCosts, creditDataRefreshTrigger])
 
   return {
     summary,

--- a/src/hooks/common/useTransferStatus.ts
+++ b/src/hooks/common/useTransferStatus.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getApiServer } from '@/helpers/server'
+
+export type TransferStatus = 'pending' | 'processed' | 'rejected' | 'unknown'
+
+export type UseTransferStatusReturn = {
+  status: TransferStatus
+  loading: boolean
+  error?: Error
+  startPolling: (itemHash: string) => void
+  stopPolling: () => void
+}
+
+const POLL_INTERVAL = 5000
+
+export function useTransferStatus(): UseTransferStatusReturn {
+  const [status, setStatus] = useState<TransferStatus>('unknown')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | undefined>()
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const itemHashRef = useRef<string | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [])
+
+  const checkStatus = useCallback(async (hash: string) => {
+    try {
+      const apiServer = getApiServer()
+      const response = await fetch(`${apiServer}/api/v0/messages/${hash}`)
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          setStatus('pending')
+          return false
+        }
+        throw new Error(`API error: ${response.status}`)
+      }
+
+      const data = await response.json()
+      const messageStatus = data?.status || data?.message?.status
+
+      if (messageStatus === 'processed') {
+        setStatus('processed')
+        return true
+      } else if (messageStatus === 'rejected') {
+        setStatus('rejected')
+        return true
+      } else {
+        setStatus('pending')
+        return false
+      }
+    } catch (err) {
+      console.error('Error checking transfer status:', err)
+      setError(err as Error)
+      return false
+    }
+  }, [])
+
+  const startPolling = useCallback(
+    (itemHash: string) => {
+      stopPolling()
+      setStatus('pending')
+      setLoading(true)
+      setError(undefined)
+      itemHashRef.current = itemHash
+
+      const poll = async () => {
+        const isDone = await checkStatus(itemHash)
+        if (isDone) {
+          stopPolling()
+          setLoading(false)
+        }
+      }
+
+      poll()
+
+      intervalRef.current = setInterval(poll, POLL_INTERVAL)
+    },
+    [checkStatus, stopPolling],
+  )
+
+  useEffect(() => {
+    return () => {
+      stopPolling()
+    }
+  }, [stopPolling])
+
+  return {
+    status,
+    loading,
+    error,
+    startPolling,
+    stopPolling,
+  }
+}

--- a/src/hooks/form/useCheckoutNotification.tsx
+++ b/src/hooks/form/useCheckoutNotification.tsx
@@ -190,6 +190,11 @@ export const stepsCatalog: Record<CheckoutStepType, CheckoutNotificationStep> =
       content:
         'By signing this transaction, you confirm the payment for your credit top-up. This will transfer the specified amount from your wallet.',
     },
+    creditTransfer: {
+      title: 'Sign Credit Transfer',
+      content:
+        'By signing this message, you confirm the transfer of credits to the specified recipient(s). This action cannot be undone.',
+    },
     permissions: {
       title: 'Sign Permissions Creation',
       content:

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,8 @@ import '@/config/reown'
 import TopUpCreditsModal from '@/components/modals/TopUpCreditsModal'
 import ReportIssueModal from '@/components/modals/ReportIssueModal'
 import { GlobalPaymentStatusModal } from '@/components/modals/PaymentStatusModal'
+import CreditTransferModal from '@/components/modals/CreditTransferModal'
+import TransferStatusModal from '@/components/modals/TransferStatusModal'
 import { useGlobalPaymentTracking } from '@/hooks/common/useGlobalPaymentTracking'
 
 function GlobalEffects() {
@@ -51,6 +53,8 @@ export default function App({ Component, pageProps }: AppProps) {
             <ReportIssueModal />
             <TopUpCreditsModal />
             <GlobalPaymentStatusModal />
+            <CreditTransferModal />
+            <TransferStatusModal />
             <Viewport>
               <Sidebar />
               <Main ref={mainRef}>

--- a/src/pages/console/credits/index.ts
+++ b/src/pages/console/credits/index.ts
@@ -1,0 +1,3 @@
+import CreditsDashboardPage from '@/components/pages/console/CreditsDashboardPage'
+
+export default CreditsDashboardPage

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -13,6 +13,7 @@ export type UIState = {
   isCreditTransferModalOpen: boolean
   isTransferStatusModalOpen: boolean
   transferStatusItemHash?: string
+  creditDataRefreshTrigger: number
 }
 
 export const initialUIState: UIState = {
@@ -25,6 +26,7 @@ export const initialUIState: UIState = {
   isCreditTransferModalOpen: false,
   isTransferStatusModalOpen: false,
   transferStatusItemHash: undefined,
+  creditDataRefreshTrigger: 0,
 }
 
 export enum UIActionType {
@@ -36,6 +38,7 @@ export enum UIActionType {
   CLOSE_PAYMENT_STATUS_MODAL = 'CLOSE_PAYMENT_STATUS_MODAL',
   OPEN_REPORT_ISSUE_MODAL = 'OPEN_REPORT_ISSUE_MODAL',
   CLOSE_REPORT_ISSUE_MODAL = 'CLOSE_REPORT_ISSUE_MODAL',
+  TRIGGER_CREDIT_DATA_REFRESH = 'TRIGGER_CREDIT_DATA_REFRESH',
   OPEN_CREDIT_TRANSFER_MODAL = 'OPEN_CREDIT_TRANSFER_MODAL',
   CLOSE_CREDIT_TRANSFER_MODAL = 'CLOSE_CREDIT_TRANSFER_MODAL',
   OPEN_TRANSFER_STATUS_MODAL = 'OPEN_TRANSFER_STATUS_MODAL',
@@ -88,6 +91,11 @@ export type CloseReportIssueModalAction = {
   payload: undefined
 }
 
+export type TriggerCreditDataRefreshAction = {
+  type: UIActionType.TRIGGER_CREDIT_DATA_REFRESH
+  payload: undefined
+}
+
 export type OpenCreditTransferModalAction = {
   type: UIActionType.OPEN_CREDIT_TRANSFER_MODAL
   payload: undefined
@@ -119,6 +127,7 @@ export type UIAction =
   | ClosePaymentStatusModalAction
   | OpenReportIssueModalAction
   | CloseReportIssueModalAction
+  | TriggerCreditDataRefreshAction
   | OpenCreditTransferModalAction
   | CloseCreditTransferModalAction
   | OpenTransferStatusModalAction
@@ -186,6 +195,13 @@ export function getUIReducer(): UIReducer {
           ...state,
           isReportIssueModalOpen: false,
           reportIssueMetadata: undefined,
+        }
+      }
+
+      case UIActionType.TRIGGER_CREDIT_DATA_REFRESH: {
+        return {
+          ...state,
+          creditDataRefreshTrigger: state.creditDataRefreshTrigger + 1,
         }
       }
 
@@ -291,6 +307,13 @@ export function openReportIssueModal(
 export function closeReportIssueModal(): CloseReportIssueModalAction {
   return {
     type: UIActionType.CLOSE_REPORT_ISSUE_MODAL,
+    payload: undefined,
+  }
+}
+
+export function triggerCreditDataRefresh(): TriggerCreditDataRefreshAction {
+  return {
+    type: UIActionType.TRIGGER_CREDIT_DATA_REFRESH,
     payload: undefined,
   }
 }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -10,6 +10,9 @@ export type UIState = {
   isPaymentStatusModalOpen: boolean
   isReportIssueModalOpen: boolean
   reportIssueMetadata?: ReportIssueMetadata
+  isCreditTransferModalOpen: boolean
+  isTransferStatusModalOpen: boolean
+  transferStatusItemHash?: string
 }
 
 export const initialUIState: UIState = {
@@ -19,6 +22,9 @@ export const initialUIState: UIState = {
   isPaymentStatusModalOpen: false,
   isReportIssueModalOpen: false,
   reportIssueMetadata: undefined,
+  isCreditTransferModalOpen: false,
+  isTransferStatusModalOpen: false,
+  transferStatusItemHash: undefined,
 }
 
 export enum UIActionType {
@@ -30,6 +36,10 @@ export enum UIActionType {
   CLOSE_PAYMENT_STATUS_MODAL = 'CLOSE_PAYMENT_STATUS_MODAL',
   OPEN_REPORT_ISSUE_MODAL = 'OPEN_REPORT_ISSUE_MODAL',
   CLOSE_REPORT_ISSUE_MODAL = 'CLOSE_REPORT_ISSUE_MODAL',
+  OPEN_CREDIT_TRANSFER_MODAL = 'OPEN_CREDIT_TRANSFER_MODAL',
+  CLOSE_CREDIT_TRANSFER_MODAL = 'CLOSE_CREDIT_TRANSFER_MODAL',
+  OPEN_TRANSFER_STATUS_MODAL = 'OPEN_TRANSFER_STATUS_MODAL',
+  CLOSE_TRANSFER_STATUS_MODAL = 'CLOSE_TRANSFER_STATUS_MODAL',
 }
 
 export type OpenTopUpCreditsModalAction = {
@@ -78,6 +88,28 @@ export type CloseReportIssueModalAction = {
   payload: undefined
 }
 
+export type OpenCreditTransferModalAction = {
+  type: UIActionType.OPEN_CREDIT_TRANSFER_MODAL
+  payload: undefined
+}
+
+export type CloseCreditTransferModalAction = {
+  type: UIActionType.CLOSE_CREDIT_TRANSFER_MODAL
+  payload: undefined
+}
+
+export type OpenTransferStatusModalAction = {
+  type: UIActionType.OPEN_TRANSFER_STATUS_MODAL
+  payload: {
+    itemHash: string
+  }
+}
+
+export type CloseTransferStatusModalAction = {
+  type: UIActionType.CLOSE_TRANSFER_STATUS_MODAL
+  payload: undefined
+}
+
 export type UIAction =
   | OpenTopUpCreditsModalAction
   | CloseTopUpCreditsModalAction
@@ -87,6 +119,10 @@ export type UIAction =
   | ClosePaymentStatusModalAction
   | OpenReportIssueModalAction
   | CloseReportIssueModalAction
+  | OpenCreditTransferModalAction
+  | CloseCreditTransferModalAction
+  | OpenTransferStatusModalAction
+  | CloseTransferStatusModalAction
 
 export type UIReducer = StoreReducer<UIState, UIAction>
 
@@ -150,6 +186,36 @@ export function getUIReducer(): UIReducer {
           ...state,
           isReportIssueModalOpen: false,
           reportIssueMetadata: undefined,
+        }
+      }
+
+      case UIActionType.OPEN_CREDIT_TRANSFER_MODAL: {
+        return {
+          ...state,
+          isCreditTransferModalOpen: true,
+        }
+      }
+
+      case UIActionType.CLOSE_CREDIT_TRANSFER_MODAL: {
+        return {
+          ...state,
+          isCreditTransferModalOpen: false,
+        }
+      }
+
+      case UIActionType.OPEN_TRANSFER_STATUS_MODAL: {
+        return {
+          ...state,
+          isTransferStatusModalOpen: true,
+          transferStatusItemHash: action.payload.itemHash,
+        }
+      }
+
+      case UIActionType.CLOSE_TRANSFER_STATUS_MODAL: {
+        return {
+          ...state,
+          isTransferStatusModalOpen: false,
+          transferStatusItemHash: undefined,
         }
       }
 
@@ -225,6 +291,36 @@ export function openReportIssueModal(
 export function closeReportIssueModal(): CloseReportIssueModalAction {
   return {
     type: UIActionType.CLOSE_REPORT_ISSUE_MODAL,
+    payload: undefined,
+  }
+}
+
+export function openCreditTransferModal(): OpenCreditTransferModalAction {
+  return {
+    type: UIActionType.OPEN_CREDIT_TRANSFER_MODAL,
+    payload: undefined,
+  }
+}
+
+export function closeCreditTransferModal(): CloseCreditTransferModalAction {
+  return {
+    type: UIActionType.CLOSE_CREDIT_TRANSFER_MODAL,
+    payload: undefined,
+  }
+}
+
+export function openTransferStatusModal(
+  itemHash: string,
+): OpenTransferStatusModalAction {
+  return {
+    type: UIActionType.OPEN_TRANSFER_STATUS_MODAL,
+    payload: { itemHash },
+  }
+}
+
+export function closeTransferStatusModal(): CloseTransferStatusModalAction {
+  return {
+    type: UIActionType.CLOSE_TRANSFER_STATUS_MODAL,
     payload: undefined,
   }
 }


### PR DESCRIPTION
## Summary

  New dedicated credits management page at `/console/credits` with comprehensive tools for monitoring and managing Aleph Cloud credits.

  ### Credits Dashboard (`/console/credits`)

  **Header Overview**
  - Balance, total spent, and expense rates (hourly/daily/monthly/yearly) using `/costs` API
  - Estimated run time with years/months/days/hours breakdown
  - Low balance warning when remaining time is under 72 hours

  **Charts (collapsible)**
  - Pie chart: service count by resource type (Instance, GPU, Confidential, Volume, Website)
  - Pie chart: daily expense share by resource type with amounts and percentages
  - 30-day line chart: daily expenses (red) and running balance (green) with dual Y-axis

  **Purchases Section**
  - Recent purchases table with status tracking, amount paid, credits received, tx links
  - Top Up Balance button opens existing top-up modal
  - Full history via side panel

  **Credit History Section**
  - Tab-based filtering: All, Transfers, Expenses, Purchases
  - 4 different table schemas per tab with relevant columns:
    - **Expenses**: amount, resource (INSTANCE/STORE links), CRN node (in-app or explorer link)
    - **Transfers**: amount (colored by direction), sender/receiver, expiration
    - **Purchases**: amount, bonus, price/credit, payment tx (Etherscan), payment message
  - In/Out direction checkboxes for All and Transfers tabs
  - Full-text search across all fields, server-side pagination
  - Proper explorer URLs using correct message types and sender addresses

  **Service Costs Section**
  - Per-resource cost breakdown from `/costs` API
  - Links to in-app resource detail pages by type
  - Total spent, cost/hour, cost/day per resource

  **Expiring Balances Section**
  - Transfers with expiration dates, sorted by nearest expiration
  - Expired entries highlighted in red with warning icon

  **Credit Transfer Modal**
  - `useForm` + Zod schema validation with `useFieldArray` for dynamic recipients
  - Amount input in dollars with "Max" button (converts to integer credits on submit)
  - Optional expiration date per recipient
  - Duplicate address validation
  - `useCheckoutNotification` integration for signing step
  - Transfer status modal with polling and explorer link

  ### Console Dashboard Changes

  - Replaced manager-based cost calculation with `/costs` API endpoint
  - Estimated run time now shows full Y/M/D/H breakdown (was days-only)
  - Removed unused entity filtering, managers, and status hooks
  - Sticky table headers on purchases table

  ### Data Refresh System

  - `creditDataRefreshTrigger` in UI store triggers all credit-related data refetch
  - Fires when: transfer is processed (status modal polling), top-up completes (global payment tracking)
  - Hooks that react: `useCreditHistory`, `useServiceCosts`, `useCreditPaymentHistory`, `usePaymentMethod` (balance)

  ### Navigation

  - New "Credits" entry in console sidebar with credit-card icon
  - Breadcrumb support

  ## Test plan

  - [ ] Navigate to `/console/credits` - page renders with all sections
  - [ ] Connect wallet - stats header shows balance, total spent, expense rates
  - [ ] Expand charts - pie charts and line chart render with data
  - [ ] Expand purchases - table shows recent purchases, click opens status modal
  - [ ] Switch credit history tabs - each tab shows correct filtered data with proper columns
  - [ ] Search in credit history - filters across all fields
  - [ ] Click Transfer Credits - modal opens with form validation
  - [ ] Submit a transfer - status modal tracks progress, data refreshes on completion
  - [ ] Click Top Up Balance - existing top-up flow works, data refreshes on completion
  - [ ] Check `/console` dashboard - estimated run time shows Y/M/D/H format
  - [ ] Test responsive layout - sections stack on mobile
  - [ ] Verify explorer links open correct URLs for each message type