### PR TITLE
fix: prevent executable status from stalling on LOADING when fetches hang

### DIFF
--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -254,8 +254,11 @@ export abstract class ExecutableManager<T extends Executable> {
     account?: Account,
   ): Promise<StreamPaymentDetails | undefined>
 
-  async checkStatus(executable: T): Promise<ExecutableStatus | undefined> {
-    const node = await this.getAllocationCRN(executable)
+  async checkStatus(
+    executable: T,
+    signal?: AbortSignal,
+  ): Promise<ExecutableStatus | undefined> {
+    const node = await this.getAllocationCRN(executable, signal)
     if (!node) return
 
     const { address } = node
@@ -263,7 +266,9 @@ export abstract class ExecutableManager<T extends Executable> {
 
     const nodeUrl = NodeManager.normalizeUrl(address)
 
-    const { version, json: response } = await this.fetchExecutions(nodeUrl)
+    const { version, json: response } = await this.fetchExecutions(nodeUrl, {
+      signal,
+    })
 
     const hash = executable.id
 
@@ -328,12 +333,15 @@ export abstract class ExecutableManager<T extends Executable> {
     }
   }
 
-  async getAllocationCRN(executable: T): Promise<CRNSpecs | undefined> {
+  async getAllocationCRN(
+    executable: T,
+    signal?: AbortSignal,
+  ): Promise<CRNSpecs | undefined> {
     if (executable.payment?.type === PaymentType.superfluid) {
       const { receiver } = executable.payment
       if (!receiver) return
 
-      const nodes = await this.nodeManager.getAllCRNsSpecs()
+      const nodes = await this.nodeManager.getAllCRNsSpecs(signal)
 
       // @note: 1) Try to filter the node by the requirements field on the executable message (legacy messages doesn't contain it)
 
@@ -352,6 +360,7 @@ export abstract class ExecutableManager<T extends Executable> {
 
     const query = await fetch(
       `https://scheduler.api.aleph.sh/api/v0/allocation/${executable.id}`,
+      { signal },
     )
 
     if (query.status === 404) return
@@ -360,7 +369,7 @@ export abstract class ExecutableManager<T extends Executable> {
 
     const { node_id, url } = response.node
 
-    const nodes = await this.nodeManager.getAllCRNsSpecs()
+    const nodes = await this.nodeManager.getAllCRNsSpecs(signal)
 
     // @note: 1) Try to filter the node by node hash
     let node = nodes.find((node) => node.hash === node_id)

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -469,7 +469,7 @@ export class NodeManager {
     }
   }
 
-  async getAllCRNsSpecs(): Promise<CRNSpecs[]> {
+  async getAllCRNsSpecs(signal?: AbortSignal): Promise<CRNSpecs[]> {
     try {
       const response = await fetchAndCache(
         crnListProgramUrl,
@@ -491,6 +491,8 @@ export class NodeManager {
             crns: formattedCrns,
           }
         },
+        false,
+        signal,
       )
 
       return response.crns

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -477,6 +477,7 @@ export async function fetchAndCache<T = unknown, P = unknown>(
   cacheTime: number,
   parse?: (data: T) => P | Promise<P>,
   log = false,
+  signal?: AbortSignal,
 ): Promise<P> {
   const cached = localStorage.getItem(cacheKey)
   const now = Date.now()
@@ -490,7 +491,7 @@ export async function fetchAndCache<T = unknown, P = unknown>(
   }
 
   try {
-    const data = await fetch(url)
+    const data = await fetch(url, { signal })
     let value = await data.json()
 
     if (parse) {

--- a/src/hooks/common/useExecutableActions.ts
+++ b/src/hooks/common/useExecutableActions.ts
@@ -100,7 +100,8 @@ export function useExecutableActions({
   const [deleteLoading, setDeleteLoading] = useState(false)
 
   useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 10_000)
 
     async function load() {
       setCRN(undefined)
@@ -108,16 +109,25 @@ export function useExecutableActions({
       if (!manager) return
       if (!executable) return
 
-      const node = await manager.getAllocationCRN(executable)
-      if (cancelled) return
+      try {
+        const node = await manager.getAllocationCRN(
+          executable,
+          controller.signal,
+        )
+        if (controller.signal.aborted) return
 
-      setCRN(node)
+        setCRN(node)
+      } catch (e) {
+        if (controller.signal.aborted) return
+        console.warn('Failed to resolve allocation CRN', e)
+      }
     }
 
     load()
 
     return () => {
-      cancelled = true
+      clearTimeout(timeoutId)
+      controller.abort()
     }
   }, [executable, manager])
 

--- a/src/hooks/common/useExecutableStatus.ts
+++ b/src/hooks/common/useExecutableStatus.ts
@@ -25,6 +25,15 @@ export type UseExecutableStatusReturn = {
 
 const BOOST_INTERVAL_MS = 2000
 const BOOST_MAX_REQUESTS = 10
+// Per-request hard ceiling. A hung CRN/scheduler fetch must not leave the
+// badge stuck on LOADING; on timeout we transition to 'not-allocated' and
+// the next poll tick retries.
+const REQUEST_TIMEOUT_MS = 10_000
+
+type InflightRequest = {
+  controller: AbortController
+  supersede: () => void
+}
 
 export function useExecutableStatus({
   executable,
@@ -38,6 +47,7 @@ export function useExecutableStatus({
   const boostCountRef = useRef(0)
   const isBoostActiveRef = useRef(false)
   const onBoostCompleteRef = useRef<(() => void) | undefined>()
+  const inflightRef = useRef<InflightRequest | null>(null)
 
   const calculatedStatus: ExecutableCalculatedStatus = useMemo(() => {
     return calculateExecutableStatus(
@@ -56,16 +66,62 @@ export function useExecutableStatus({
     if (!manager) return
     if (!executable) return
 
+    const cancelInflight = () => {
+      const inflight = inflightRef.current
+      if (!inflight) return
+      inflightRef.current = null
+      inflight.supersede()
+    }
+
     async function request() {
       if (!manager) return
       if (!executable) return
       if (isBoostActiveRef.current) return
 
+      cancelInflight()
+
+      const controller = new AbortController()
+      let superseded = false
+      let timedOut = false
+
+      const inflight: InflightRequest = {
+        controller,
+        supersede: () => {
+          superseded = true
+          controller.abort()
+        },
+      }
+      inflightRef.current = inflight
+
+      const timeoutId = setTimeout(() => {
+        timedOut = true
+        controller.abort()
+      }, REQUEST_TIMEOUT_MS)
+
       try {
-        const fetchedStatus = await manager.checkStatus(executable)
+        const fetchedStatus = await manager.checkStatus(
+          executable,
+          controller.signal,
+        )
+        if (superseded) return
         setStatus(fetchedStatus)
-      } finally {
         setHasTriedFetchingStatus(true)
+      } catch (e) {
+        if (superseded) return
+        if (timedOut) {
+          console.warn(
+            `Executable status fetch timed out after ${REQUEST_TIMEOUT_MS}ms`,
+            executable?.id,
+          )
+        } else {
+          console.warn('Executable status fetch failed', e)
+        }
+        setHasTriedFetchingStatus(true)
+      } finally {
+        clearTimeout(timeoutId)
+        if (inflightRef.current === inflight) {
+          inflightRef.current = null
+        }
       }
     }
 
@@ -78,7 +134,10 @@ export function useExecutableStatus({
       request()
     }, 10 * 1000)
 
-    return () => clearInterval(id)
+    return () => {
+      clearInterval(id)
+      cancelInflight()
+    }
   }, [executable, manager])
 
   // Boost polling - fast polling after action buttons are pressed
@@ -115,8 +174,17 @@ export function useExecutableStatus({
           return
         }
 
+        const controller = new AbortController()
+        const timeoutId = setTimeout(
+          () => controller.abort(),
+          REQUEST_TIMEOUT_MS,
+        )
+
         try {
-          const fetchedStatus = await manager.checkStatus(executable)
+          const fetchedStatus = await manager.checkStatus(
+            executable,
+            controller.signal,
+          )
           setStatus(fetchedStatus)
           setHasTriedFetchingStatus(true)
 
@@ -133,6 +201,8 @@ export function useExecutableStatus({
           }
         } catch {
           // Silently fail on boost requests
+        } finally {
+          clearTimeout(timeoutId)
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes the bug where the instance detail page badge on app.aleph.cloud can stay stuck on `LOADING` indefinitely even though the instance is actually running on the CRN.

## Root cause

`useExecutableStatus` relies on a `try { ... } finally { setHasTriedFetchingStatus(true) }` to flip the badge out of `'loading'`. The `finally` only runs when `await manager.checkStatus(executable)` settles — and the underlying browser `fetch` calls have **no timeout**. If the scheduler, the CRN list endpoint, or the CRN's `/v2/about/executions/list` stalls (idle HTTP/2 stream, captive portal, extension interference, etc.), the `await` never settles, `hasTriedFetchingStatus` stays `false`, and the calculator stays on `'loading'` forever. The 10s poll interval re-fires `request()` without aborting the prior in-flight call, so zombie requests pile up.

Surfaced by credit-payment instances since they were recently routed through this code path (`getAllocationCRN` falls through to the scheduler branch for any non-superfluid payment), but the issue is generic to every non-PAYG instance.

## Changes

- Thread an optional `AbortSignal` through `ExecutableManager.checkStatus`, `getAllocationCRN`, `fetchAndCache`, and `NodeManager.getAllCRNsSpecs`. All `fetch` calls in the status path now honor the signal.
- In `useExecutableStatus`, wrap each request with an `AbortController` + a 10s timeout, abort the prior request on each poll tick and on effect cleanup, and distinguish *supersession*-aborts (no state change — a newer request is taking over) from *timeout*-aborts (transition to `'not-allocated'` so the badge escapes `'loading'`).
- Apply the same abort + timeout pattern to the secondary `getAllocationCRN` effect in `useExecutableActions`.
- Apply the abort + timeout pattern to boost polling too so action-button retries can't pile up zombie requests.
- Add a `catch` in the main request so non-abort failures land in the console instead of becoming unhandled rejections.

## Behavior after the fix

| Scenario | Before | After |
|---|---|---|
| Fetch hangs | Badge stuck on `LOADING` forever | Badge transitions to `NOT ALLOCATED` after 10s; next poll tick retries |
| New poll tick while prior request still pending | Both requests run in parallel; zombies accumulate | Prior request aborted, only the latest one is honored |
| Component unmounts mid-request | Request continues, may call `setState` after unmount | Request is aborted |
| Real network error (5xx, DNS reject, CORS) | Badge stays `LOADING` (no `catch`) | `catch` logs the error and transitions to `NOT ALLOCATED` |
| Success | Unchanged | Unchanged |

## Out of scope (follow-ups)

- `useRequestExecutableStatus` (used by the dashboard list view) has the same latent hanging-fetch problem on `checkStatus`. Same pattern would apply but it's a separate symptom from the user-reported detail-page bug.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `npm run lint:fix` clean (verified locally)
- [ ] Open the detail page of a credit instance whose CRN is reachable — badge resolves to `RUNNING` and CRN/SSH/IPv4 sections populate as before.
- [ ] Block traffic to one of the CRN endpoints (e.g., via devtools network throttling/blocking) — badge transitions to `NOT ALLOCATED` within ~10s instead of staying on `LOADING`.
- [ ] Click Start/Stop/Reboot on a PAYG instance — boost polling still functions; no UI regression.
- [ ] Navigate away from the detail page while the status fetch is in flight — no `setState` on unmounted component warnings in the console.