### PR TITLE
feat(crn): make Ready to link filter available when disconnected

### DIFF
--- a/src/components/pages/account/ComputeResourceNodesPage/cmp.tsx
+++ b/src/components/pages/account/ComputeResourceNodesPage/cmp.tsx
@@ -146,7 +146,7 @@ export const ComputeResourceNodesPage = (
                   onTabChange={handleTabChange}
                 />
                 <Checkbox
-                  label="Ready to link"
+                  label="Available to link"
                   checked={isLinkableOnly}
                   onChange={handleLinkableOnlyChange}
                   size="xs"

--- a/src/components/pages/account/ComputeResourceNodesPage/hook.tsx
+++ b/src/components/pages/account/ComputeResourceNodesPage/hook.tsx
@@ -131,10 +131,8 @@ export function useComputeResourceNodesPage(
 
   const linkableNodes = useMemo(() => {
     if (!baseFilteredNodes) return
-    return baseFilteredNodes.filter(
-      (node) => nodeManager.isLinkableBy(node, userNode)[0],
-    )
-  }, [baseFilteredNodes, nodeManager, userNode])
+    return baseFilteredNodes.filter((node) => nodeManager.isLinkable(node)[0])
+  }, [baseFilteredNodes, nodeManager])
 
   const isLinkableOnlyDisabled =
     !linkableNodes?.length || selectedTab !== 'nodes'
@@ -146,9 +144,8 @@ export function useComputeResourceNodesPage(
 
   const filteredNodes = useMemo(() => {
     if (!isLinkableOnly) return baseFilteredNodes
-    if (!account) return baseFilteredNodes
     return linkableNodes
-  }, [account, baseFilteredNodes, linkableNodes, isLinkableOnly])
+  }, [baseFilteredNodes, linkableNodes, isLinkableOnly])
 
   // ----------------------------- PAGINATE
 

--- a/src/domain/aggregateManager.ts
+++ b/src/domain/aggregateManager.ts
@@ -9,11 +9,9 @@ import Err from '@/helpers/errors'
 
 export type AggregateContent<T> = Record<string, T | null>
 
-export abstract class AggregateManager<
-  Entity,
-  AddEntity,
-  AggregateItem,
-> implements EntityManager<Entity, AddEntity> {
+export abstract class AggregateManager<Entity, AddEntity, AggregateItem>
+  implements EntityManager<Entity, AddEntity>
+{
   protected abstract addStepType: CheckoutStepType
   protected abstract delStepType: CheckoutStepType
 

--- a/src/domain/file.ts
+++ b/src/domain/file.ts
@@ -11,13 +11,7 @@ import {
   AlephHttpClient,
   AuthenticatedAlephHttpClient,
 } from '@aleph-sdk/client'
-import {
-  ItemType,
-  MessageType,
-  PaymentType,
-  StoreMessage,
-} from '@aleph-sdk/message'
-import { Blockchain } from '@aleph-sdk/core'
+import { ItemType, MessageType, StoreMessage } from '@aleph-sdk/message'
 import Err from '@/helpers/errors'
 import {
   DEFAULT_PAGE_SIZE,
@@ -214,7 +208,6 @@ export class FileManager {
         name: fileObject.name,
         format: fileObject.type,
       },
-      payment: { chain: Blockchain.ETH, type: PaymentType.credit },
     })
 
     // Create a properly typed object including both message properties and our additional fields

--- a/src/domain/volume.ts
+++ b/src/domain/volume.ts
@@ -3,7 +3,6 @@ import {
   ItemType,
   MessageCostLine,
   MessageType,
-  Payment,
   PaymentType,
   StoreContent,
 } from '@aleph-sdk/message'
@@ -209,12 +208,6 @@ export class VolumeManager implements EntityManager<Volume, AddVolume> {
     try {
       const { channel } = this
 
-      // Hardcode credit payment as the only valid payment method
-      const creditPayment: Payment = {
-        chain: Blockchain.ETH,
-        type: PaymentType.credit,
-      }
-
       // @note: Aggregate all signatures in 1 step
       yield
       const response = await Promise.all([
@@ -223,7 +216,6 @@ export class VolumeManager implements EntityManager<Volume, AddVolume> {
           (this.sdkClient as AuthenticatedAlephHttpClient).createStore({
             channel,
             fileObject,
-            payment: creditPayment,
           }),
         ),
         // IPFS-based volumes (pinning via STORE message)
@@ -232,7 +224,6 @@ export class VolumeManager implements EntityManager<Volume, AddVolume> {
             channel,
             fileHash: cid,
             storageEngine: ItemType.ipfs,
-            payment: creditPayment,
           }),
         ),
       ])

--- a/src/domain/website.ts
+++ b/src/domain/website.ts
@@ -369,7 +369,6 @@ export class WebsiteManager implements EntityManager<Website, AddWebsite> {
         channel: this.channel,
         fileHash: website.cid as string,
         storageEngine: ItemType.ipfs,
-        payment: { chain: Blockchain.ETH, type: PaymentType.credit },
       })
       const volumeEntity = (await this.volumeManager.parseMessages([volume]))[0]
 
@@ -533,7 +532,6 @@ export class WebsiteManager implements EntityManager<Website, AddWebsite> {
           channel: this.channel,
           fileHash: cid,
           storageEngine: ItemType.ipfs,
-          payment: { chain: Blockchain.ETH, type: PaymentType.credit },
         })
         const volumeEntity = (
           await this.volumeManager.parseMessages([volume])


### PR DESCRIPTION
## Summary
- The **Ready to link** checkbox on `/account/earn/crn` (All compute nodes tab) was disabled for anyone not connected with a CCN account that has a free slot. Reported by a user who wanted access to it while disconnected.
- Fix: the linkable-nodes filter now uses the user-independent `nodeManager.isLinkable(node)` (not-locked, not-already-linked) instead of `isLinkableBy(node, userNode)`, and `filteredNodes` no longer bails out when there's no connected account. The checkbox is now enabled for everyone on the "All compute nodes" tab; it filters to CRNs that are actually available to link.

## Build unblock (separate commit)
- The base `feat/credits-ui` branch did not compile: WIP commit `e4f1c66f` added a `payment` field to `createStore` calls in `file.ts`, `volume.ts`, and `website.ts`. The installed `@aleph-sdk` `createStore` accepts `Omit<StorePublishConfiguration, 'account'>`, which has **no** `payment` field — the SDK's store `prepareMessageContent` never reads it and the published store message carries no payment data. The fields were no-ops at runtime, so removing them changes no behavior and fixes the type errors. Also applies a pending prettier reformat in `aggregateManager.ts`.
- ⚠️ **Follow-up needed:** credits-for-STORE (storage/volume/website uploads) is not functional with the current SDK. To actually ship it, `@aleph-sdk` needs a version whose `createStore` supports `payment`.

## Test plan
- [ ] Open `/account/earn/crn` **disconnected** → on "All compute nodes" tab, "Ready to link" checkbox is enabled; ticking it filters to available-to-link CRNs.
- [ ] Connected with a CCN that has a free slot → checkbox still works as before.
- [ ] `npm run build` and `npm run lint` pass.