### PR TITLE
fix: read rewards from credit-rewards-distribution posts

### DIFF
--- a/src/components/common/Header/hook.ts
+++ b/src/components/common/Header/hook.ts
@@ -169,13 +169,13 @@ export function useHeader(): UseHeaderReturn {
   }, [lastDistribution])
 
   const rewards = useMemo(() => {
-    if (!userRewards) return
+    if (!account) return
 
     return {
-      amount: userRewards,
+      amount: userRewards ?? 0,
       days: pendingDays,
     }
-  }, [pendingDays, userRewards])
+  }, [account, pendingDays, userRewards])
 
   return {
     accountAddress: account?.address,

--- a/src/domain/stake.ts
+++ b/src/domain/stake.ts
@@ -94,25 +94,29 @@ export class StakeManager {
     // @note: Consume socket first step
     await feed.next()
 
-    for await (const data of feed) {
-      if (!data.content) continue
-      if (!data.content.content) continue
+    try {
+      for await (const data of feed) {
+        if (!data.content) continue
+        if (!data.content.content) continue
 
-      const { content, time } = data.content || {}
-      const { status: type, rewards, end_height: lastHeight } = content
+        const { content, time } = data.content || {}
+        const { status: type, rewards, end_height: lastHeight } = content
 
-      if (
-        type === 'calculation' ||
-        (type === 'distribution' &&
-          data.content.content.targets.some(({ success }: any) => success))
-      ) {
-        yield {
-          type,
-          rewards,
-          lastHeight,
-          timestamp: Math.trunc(time * 1000),
+        if (
+          type === 'calculation' ||
+          (type === 'distribution' &&
+            data.content.content.targets.some(({ success }: any) => success))
+        ) {
+          yield {
+            type,
+            rewards,
+            lastHeight,
+            timestamp: Math.trunc(time * 1000),
+          }
         }
       }
+    } catch (error) {
+      console.error('Rewards feed subscription error:', error)
     }
   }
 

--- a/src/domain/stake.ts
+++ b/src/domain/stake.ts
@@ -45,7 +45,7 @@ export class StakeManager {
 
   async getLastRewardsCalculation(): Promise<RewardsResponse> {
     const res = await this.sdkClient.getPosts({
-      types: 'staking-rewards-distribution',
+      types: 'credit-rewards-distribution',
       addresses: [monitorAddress],
       tags: ['calculation'],
       pagination: 1,
@@ -65,7 +65,7 @@ export class StakeManager {
 
   async getLastRewardsDistribution(): Promise<RewardsResponse> {
     const res = await this.sdkClient.getPosts({
-      types: 'staking-rewards-distribution',
+      types: 'credit-rewards-distribution',
       addresses: [senderAddress],
       tags: ['distribution'],
       pagination: 1,
@@ -87,7 +87,7 @@ export class StakeManager {
     abort: Promise<void>,
   ): AsyncGenerator<RewardsResponse> {
     const feed = subscribeSocketFeed<PostMessage<any>>(
-      `${wsServer}/api/ws0/messages?msgType=POST&history=1&contentTypes=staking-rewards-distribution&addresses=${senderAddress},${monitorAddress}`,
+      `${wsServer}/api/ws0/messages?msgType=POST&history=1&contentTypes=credit-rewards-distribution&addresses=${senderAddress},${monitorAddress}`,
       abort,
     )
 
@@ -95,8 +95,8 @@ export class StakeManager {
     await feed.next()
 
     for await (const data of feed) {
-      if (!data.content) return
-      if (!data.content.content) return
+      if (!data.content) continue
+      if (!data.content.content) continue
 
       const { content, time } = data.content || {}
       const { status: type, rewards, end_height: lastHeight } = content

--- a/src/hooks/common/useRequestEntity/useRequestRewardsFeed.ts
+++ b/src/hooks/common/useRequestEntity/useRequestRewardsFeed.ts
@@ -24,13 +24,15 @@ export function useRequestRewardsFeed(): UseRequestRewardsFeedReturn {
     const abort = new Future<void>()
 
     const subscribe = async () => {
-      const lastRewardsDistribution = await manager.getLastRewardsDistribution()
+      const [lastRewardsDistribution, lastRewardsCalculation] =
+        await Promise.all([
+          manager.getLastRewardsDistribution(),
+          manager.getLastRewardsCalculation(),
+        ])
 
-      setRewards((prev) => {
-        return {
-          lastRewardsDistribution,
-          lastRewardsCalculation: prev?.lastRewardsCalculation,
-        }
+      setRewards({
+        lastRewardsDistribution,
+        lastRewardsCalculation,
       })
 
       const iterator = manager.subscribeRewardsFeed(abort.promise)

--- a/src/hooks/common/useRequestEntity/useRequestRewardsFeed.ts
+++ b/src/hooks/common/useRequestEntity/useRequestRewardsFeed.ts
@@ -24,16 +24,21 @@ export function useRequestRewardsFeed(): UseRequestRewardsFeedReturn {
     const abort = new Future<void>()
 
     const subscribe = async () => {
-      const [lastRewardsDistribution, lastRewardsCalculation] =
-        await Promise.all([
-          manager.getLastRewardsDistribution(),
-          manager.getLastRewardsCalculation(),
-        ])
+      const [distribution, calculation] = await Promise.allSettled([
+        manager.getLastRewardsDistribution(),
+        manager.getLastRewardsCalculation(),
+      ])
 
-      setRewards({
-        lastRewardsDistribution,
-        lastRewardsCalculation,
-      })
+      setRewards((prev) => ({
+        lastRewardsDistribution:
+          distribution.status === 'fulfilled'
+            ? distribution.value
+            : prev?.lastRewardsDistribution,
+        lastRewardsCalculation:
+          calculation.status === 'fulfilled'
+            ? calculation.value
+            : prev?.lastRewardsCalculation,
+      }))
 
       const iterator = manager.subscribeRewardsFeed(abort.promise)
 


### PR DESCRIPTION
## Problem

Reward estimates on the account page were frozen — they hadn't reset for over a month. The reward distribution post type was renamed on the network from `staking-rewards-distribution` to `credit-rewards-distribution` (backward compatible: same `status`/`rewards`/`end_height`, plus new fields). The frontend still filtered the old type, so it stopped seeing distributions after the last old-type one (2026-05-02) and the pending estimate never reset.

## Changes

- **`domain/stake.ts`** — point all three reward filters at `credit-rewards-distribution`: `getLastRewardsCalculation`, `getLastRewardsDistribution`, and the websocket `subscribeRewardsFeed` `contentTypes`.
- **`domain/stake.ts`** — feed now skips a malformed message (`continue`) instead of permanently terminating the generator (`return`), so live updates survive a bad message.
- **`useRequestRewardsFeed.ts`** — fetch the calculation on mount alongside the distribution, so the estimate populates regardless of which post the websocket `history=1` replays.
- **`Header/hook.ts`** — show `EST. REWARDS` whenever a wallet is connected, including when the value is 0 (previously hidden at 0).

The caption ("Next distribution in X days") is rendered inside `@aleph-front/core` and is unchanged; it now receives a real countdown off the latest distribution instead of being stuck at 0.

## Testing notes

- Network requests now use `types=credit-rewards-distribution`; the rewards websocket uses `contentTypes=credit-rewards-distribution`.
- The estimate currently shows 0 for all addresses because the backend has not yet published a `credit-rewards` **calculation** post for the phase after the 2026-06-01 distribution (the calc job needs to resume for the new phase). The frontend is wired to display the accumulated value as soon as the first new-phase calculation lands. This is a backend dependency, tracked separately.
- The pre-existing `payment`/`StorePublishConfiguration` type errors in `file.ts`/`volume.ts`/`website.ts` are unrelated to this change and already present on the base branch.