### PR TITLE
fix(store): remove unsupported payment field from createStore calls

### DIFF
--- a/src/domain/aggregateManager.ts
+++ b/src/domain/aggregateManager.ts
@@ -9,11 +9,9 @@ import Err from '@/helpers/errors'
 
 export type AggregateContent<T> = Record<string, T | null>
 
-export abstract class AggregateManager<
-  Entity,
-  AddEntity,
-  AggregateItem,
-> implements EntityManager<Entity, AddEntity> {
+export abstract class AggregateManager<Entity, AddEntity, AggregateItem>
+  implements EntityManager<Entity, AddEntity>
+{
   protected abstract addStepType: CheckoutStepType
   protected abstract delStepType: CheckoutStepType
 

--- a/src/domain/file.ts
+++ b/src/domain/file.ts
@@ -11,13 +11,7 @@ import {
   AlephHttpClient,
   AuthenticatedAlephHttpClient,
 } from '@aleph-sdk/client'
-import {
-  ItemType,
-  MessageType,
-  PaymentType,
-  StoreMessage,
-} from '@aleph-sdk/message'
-import { Blockchain } from '@aleph-sdk/core'
+import { ItemType, MessageType, StoreMessage } from '@aleph-sdk/message'
 import Err from '@/helpers/errors'
 import {
   DEFAULT_PAGE_SIZE,
@@ -214,7 +208,6 @@ export class FileManager {
         name: fileObject.name,
         format: fileObject.type,
       },
-      payment: { chain: Blockchain.ETH, type: PaymentType.credit },
     })
 
     // Create a properly typed object including both message properties and our additional fields

--- a/src/domain/volume.ts
+++ b/src/domain/volume.ts
@@ -3,7 +3,6 @@ import {
   ItemType,
   MessageCostLine,
   MessageType,
-  Payment,
   PaymentType,
   StoreContent,
 } from '@aleph-sdk/message'
@@ -209,12 +208,6 @@ export class VolumeManager implements EntityManager<Volume, AddVolume> {
     try {
       const { channel } = this
 
-      // Hardcode credit payment as the only valid payment method
-      const creditPayment: Payment = {
-        chain: Blockchain.ETH,
-        type: PaymentType.credit,
-      }
-
       // @note: Aggregate all signatures in 1 step
       yield
       const response = await Promise.all([
@@ -223,7 +216,6 @@ export class VolumeManager implements EntityManager<Volume, AddVolume> {
           (this.sdkClient as AuthenticatedAlephHttpClient).createStore({
             channel,
             fileObject,
-            payment: creditPayment,
           }),
         ),
         // IPFS-based volumes (pinning via STORE message)
@@ -232,7 +224,6 @@ export class VolumeManager implements EntityManager<Volume, AddVolume> {
             channel,
             fileHash: cid,
             storageEngine: ItemType.ipfs,
-            payment: creditPayment,
           }),
         ),
       ])

--- a/src/domain/website.ts
+++ b/src/domain/website.ts
@@ -369,7 +369,6 @@ export class WebsiteManager implements EntityManager<Website, AddWebsite> {
         channel: this.channel,
         fileHash: website.cid as string,
         storageEngine: ItemType.ipfs,
-        payment: { chain: Blockchain.ETH, type: PaymentType.credit },
       })
       const volumeEntity = (await this.volumeManager.parseMessages([volume]))[0]
 
@@ -533,7 +532,6 @@ export class WebsiteManager implements EntityManager<Website, AddWebsite> {
           channel: this.channel,
           fileHash: cid,
           storageEngine: ItemType.ipfs,
-          payment: { chain: Blockchain.ETH, type: PaymentType.credit },
         })
         const volumeEntity = (
           await this.volumeManager.parseMessages([volume])


### PR DESCRIPTION
## Summary
The base `feat/credits-ui` branch does not compile. A WIP commit added a `payment` field to `createStore` calls in `file.ts`, `volume.ts`, and `website.ts`. The installed `@aleph-sdk` `createStore` accepts `Omit<StorePublishConfiguration, 'account'>`, which has **no** `payment` field — the SDK's store `prepareMessageContent` never reads it and the published store message carries no payment data.

The fields were no-ops at runtime, so removing them changes no behavior and fixes the type errors. Also applies a pending prettier reformat in `aggregateManager.ts`.

This was split out of #225 so it can land on `feat/credits-ui` independently and unblock the build for everyone working off that branch.

## Follow-up needed
Credits-for-STORE (storage/volume/website uploads) is not functional with the current SDK. To actually ship it, `@aleph-sdk` needs a version whose `createStore` supports `payment`.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes