### PR TITLE
Feat/dedup hosting providers

### DIFF
--- a/src/components/form/AddFunctionCode/cmp.tsx
+++ b/src/components/form/AddFunctionCode/cmp.tsx
@@ -158,7 +158,7 @@ export const AddFunctionCode = React.memo((props: AddFunctionCodeProps) => {
           </>
         )}
         <div tw="mt-6 text-right">
-          <ExternalLinkButton href="https://docs.aleph.im/tools/webconsole/">
+          <ExternalLinkButton href="https://docs.aleph.cloud/devhub/compute-resources/functions/webconsole/">
             Learn more
           </ExternalLinkButton>
         </div>

--- a/src/components/form/SelectCustomFunctionRuntime/cmp.tsx
+++ b/src/components/form/SelectCustomFunctionRuntime/cmp.tsx
@@ -18,7 +18,7 @@ export const SelectCustomFunctionRuntime = React.memo(
             placeholder="f6872f58fd38cbc123e9e036861a858...079ff2c123e9e08c123e9e0368fa68e"
           />
           <div tw="mt-6 text-right">
-            <ExternalLinkButton href="https://docs.aleph.im/computing/runtimes">
+            <ExternalLinkButton href="https://docs.aleph.cloud/devhub/sdks-and-tools/aleph-cli/commands/program#supported-runtimes">
               Learn more
             </ExternalLinkButton>
           </div>

--- a/src/components/form/SelectFunctionPersistence/cmp.tsx
+++ b/src/components/form/SelectFunctionPersistence/cmp.tsx
@@ -27,7 +27,7 @@ export const SelectFunctionPersistence = React.memo(
           </RadioGroup>
         </NoisyContainer>
         <div tw="mt-6 text-right">
-          <ExternalLinkButton href="https://docs.aleph.im/computing/#persistent-execution">
+          <ExternalLinkButton href="https://docs.aleph.cloud/devhub/compute-resources/functions/#persistent-execution">
             Learn more
           </ExternalLinkButton>
         </div>

--- a/src/components/form/SelectFunctionRuntime/cmp.tsx
+++ b/src/components/form/SelectFunctionRuntime/cmp.tsx
@@ -40,7 +40,7 @@ export const SelectFunctionRuntime = React.memo(
           )}
         </NoisyContainer>
         <div tw="mt-6 text-right">
-          <ExternalLinkButton href="https://docs.aleph.im/computing/runtimes">
+          <ExternalLinkButton href="https://docs.aleph.cloud/devhub/sdks-and-tools/aleph-cli/commands/program#supported-runtimes">
             Learn more
           </ExternalLinkButton>
         </div>

--- a/src/components/form/SelectWebsiteFramework/cmp.tsx
+++ b/src/components/form/SelectWebsiteFramework/cmp.tsx
@@ -48,7 +48,7 @@ export const SelectWebsiteFramework = React.memo(
           )}
         </NoisyContainer>
         {/* <div tw="mt-6 text-right">
-          <ExternalLinkButton href="https://docs.aleph.im/">
+          <ExternalLinkButton href="https://docs.aleph.cloud/">
             Learn more
           </ExternalLinkButton>
         </div> */}

--- a/src/config/reown.ts
+++ b/src/config/reown.ts
@@ -27,8 +27,8 @@ const projectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_ID as string
 const metadata = {
   name: 'Aleph Cloud',
   description: 'Aleph Cloud: Web3 cloud solution',
-  url: 'https://account.aleph.im',
-  icons: ['https://account.aleph.im/favicon-32x32.png'],
+  url: 'https://app.aleph.cloud',
+  icons: ['https://app.aleph.cloud/favicon-32x32.png'],
 }
 
 // Adapters for different blockchain ecosystems

--- a/src/domain/instance.ts
+++ b/src/domain/instance.ts
@@ -159,7 +159,7 @@ export class InstanceManager<T extends InstanceEntity = Instance>
     //   type: EntityType.Instance,
     //   id: 'fad1426244885cf5cbb9c0507ad2e023a5ef7d3c6d2866fd61a5447be322b433',
     //   name: 'Gerard Instance detail test',
-    //   url: 'https://explorer.aleph.im/address/ETH/0x5f78199cd833c1dc1735bee4a7416caaE58Facca/message/INSTANCE/fad1426244885cf5cbb9c0507ad2e023a5ef7d3c6d2866fd61a5447be322b433',
+    //   url: 'https://explorer.aleph.cloud/address/ETH/0x5f78199cd833c1dc1735bee4a7416caaE58Facca/message/INSTANCE/fad1426244885cf5cbb9c0507ad2e023a5ef7d3c6d2866fd61a5447be322b433',
     //   date: '2025-02-21 14:50:40',
     //   size: 20480,
     //   confirmed: false,

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -1,6 +1,7 @@
 import {
   crnListProgramUrl,
   defaultAccountChannel,
+  metricAddress,
   monitorAddress,
   postType,
   scoringAddress,
@@ -113,6 +114,7 @@ export type BaseNodeScoreMeasurements = {
   base_latency_score_p95: number
   node_version_prerelease: number
   nodes_with_identical_asn: number
+  duplicate_ip?: boolean
 }
 
 export type CCNScore = BaseNodeScore & {
@@ -1145,7 +1147,7 @@ export class NodeManager {
   }> {
     const res = await this.sdkClient.getPosts({
       types: 'aleph-network-metrics',
-      addresses: [scoringAddress],
+      addresses: [metricAddress],
       pagination: 1,
       page: 1,
     })

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -15,6 +15,7 @@ export const mbPerAleph = 3
 export const communityWalletAddress =
   '0x5aBd3258C5492fD378EBC2e0017416E199e5Da56'
 export const scoringAddress = '0x4D52380D3191274a04846c89c069E6C3F2Ed94e4'
+export const metricAddress = '0x4D52380D3191274a04846c89c069E6C3F2Ed94e4'
 export const monitorAddress = '0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10'
 export const senderAddress = '0x3a5CC6aBd06B601f4654035d125F9DD2FC992C25'
 export const erc20Address = '0x27702a26126e0B3702af63Ee09aC4d1A084EF628'

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -362,7 +362,7 @@ export const NAVIGATION_URLS = {
       },
     },
   },
-  explorer: { home: 'https://explorer.aleph.im' },
+  explorer: { home: 'https://explorer.aleph.cloud' },
   swap: { home: 'https://swap.aleph.cloud' },
   docs: {
     home: 'https://docs.aleph.cloud',

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -296,7 +296,7 @@ const messageTypeWhitelist = new Set(Object.values(MessageType))
  */
 export const getExplorerURL = ({ item_hash, chain, sender, type }: Message) => {
   type = messageTypeWhitelist.has(type as MessageType) ? type : MessageType.post
-  return `https://explorer.aleph.im/address/${chain}/${sender}/message/${type}/${item_hash}`
+  return `https://explorer.aleph.cloud/address/${chain}/${sender}/message/${type}/${item_hash}`
 }
 
 /*

--- a/src/hooks/common/node/useHostingProviderTop.ts
+++ b/src/hooks/common/node/useHostingProviderTop.ts
@@ -30,14 +30,16 @@ export function useHostingProviderTop<T extends AlephNode>({
         (_, i) => ({ metricsData: { as_name: `Provider ${i}` } }) as T,
       )
 
-    return safeNodes.reduce(
-      (ac, node) => {
-        const asnName = node.metricsData?.as_name || 'others'
-        ac[asnName] = (ac[asnName] || 0) + 1
-        return ac
-      },
-      { others: 0 } as Record<string, number>,
-    )
+    return safeNodes
+      .filter((node) => node.scoreData?.measurements?.duplicate_ip !== true)
+      .reduce(
+        (ac, node) => {
+          const asnName = node.metricsData?.as_name || 'others'
+          ac[asnName] = (ac[asnName] || 0) + 1
+          return ac
+        },
+        { others: 0 } as Record<string, number>,
+      )
   }, [nodes])
 
   const total = useMemo(


### PR DESCRIPTION
Add a dedicated metricAddress constant for the aleph-network-metrics
post, separate from scoringAddress which now points to a different
account. Add optional duplicate_ip to BaseNodeScoreMeasurements and
filter duplicate-IP nodes out of the top hosting provider counts.