### PR TITLE
perf: reduce node data-fetch overhead

### DIFF
--- a/src/components/pages/account/ComputeResourceNodesPage/hook.tsx
+++ b/src/components/pages/account/ComputeResourceNodesPage/hook.tsx
@@ -198,7 +198,7 @@ export function useComputeResourceNodesPage(
 
   // ----------------------------- NETWORK RESOURCES CHART
 
-  const { specs } = useRequestCRNSpecs({ nodes })
+  const { specs } = useRequestCRNSpecs()
 
   const totalResources = useMemo(() => {
     const resources = Object.values(specs)
@@ -207,7 +207,7 @@ export function useComputeResourceNodesPage(
         ac.cpu += cv.data?.cpu?.count || 0
         ac.ram += (cv.data?.mem?.total_kB || 0) / 1024
         ac.hdd += (cv.data?.disk?.total_kB || 0) / 1024
-        ac.nodes += cv.data ? 1 : 0
+        ac.nodes += cv.data?.cpu ? 1 : 0
         ac.total += 1
 
         return ac

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -415,11 +415,16 @@ export class NodeManager {
 
     crns = this.parseResourceNodes(crns)
 
-    crns = await this.parseScores(crns, true)
-    crns = await this.parseMetrics(crns, true)
+    const [scores, metrics] = await Promise.all([
+      this.getScores(),
+      this.getMetrics(),
+    ])
 
-    ccns = await this.parseScores(ccns, false)
-    ccns = await this.parseMetrics(ccns, false)
+    crns = this.applyScores(crns, scores.crn)
+    crns = this.applyMetrics(crns, metrics.crn)
+
+    ccns = this.applyScores(ccns, scores.ccn)
+    ccns = this.applyMetrics(ccns, metrics.ccn)
 
     this.linkChildrenNodes(ccns, crns)
     this.linkParentNodes(crns, ccns)
@@ -455,11 +460,16 @@ export class NodeManager {
 
         crns = this.parseResourceNodes(crns)
 
-        crns = await this.parseScores(crns, true)
-        crns = await this.parseMetrics(crns, true)
+        const [scores, metrics] = await Promise.all([
+          this.getScores(),
+          this.getMetrics(),
+        ])
 
-        ccns = await this.parseScores(ccns, false)
-        ccns = await this.parseMetrics(ccns, false)
+        crns = this.applyScores(crns, scores.crn)
+        crns = this.applyMetrics(crns, metrics.crn)
+
+        ccns = this.applyScores(ccns, scores.ccn)
+        ccns = this.applyMetrics(ccns, metrics.ccn)
 
         this.linkChildrenNodes(ccns, crns)
         this.linkParentNodes(crns, ccns)
@@ -1082,11 +1092,10 @@ export class NodeManager {
     })
   }
 
-  protected async parseScores<T extends AlephNode>(
+  protected applyScores<T extends AlephNode>(
     nodes: T[],
-    isCRN: boolean,
-  ): Promise<T[]> {
-    const scores = isCRN ? await this.getCRNScores() : await this.getCCNScores()
+    scores: (CCNScore | CRNScore)[],
+  ): T[] {
     const scoresMap = new Map(scores.map((score) => [score.node_id, score]))
 
     return nodes.map((node) => {
@@ -1104,14 +1113,10 @@ export class NodeManager {
     })
   }
 
-  protected async parseMetrics<T extends AlephNode>(
+  protected applyMetrics<T extends AlephNode>(
     nodes: T[],
-    isCRN: boolean,
-  ): Promise<T[]> {
-    const metrics = isCRN
-      ? await this.getCRNMetrics()
-      : await this.getCCNMetrics()
-
+    metrics: (CCNMetrics | CRNMetrics)[],
+  ): T[] {
     const metricsMap = new Map(
       metrics.map((metrics) => [metrics.node_id, metrics]),
     )
@@ -1127,51 +1132,32 @@ export class NodeManager {
     })
   }
 
+  // Scores and metrics are single large posts that each carry both ccn and crn
+  // sets. Cache them so the ccn/crn passes and successive feed ticks reuse one
+  // fetch instead of re-downloading the post each time.
   protected async getScores(): Promise<{
     ccn: CCNScore[]
     crn: CRNScore[]
   }> {
-    const res = await this.sdkClient.getPosts({
-      types: 'aleph-scoring-scores',
-      addresses: [scoringAddress],
-      pagination: 1,
-      page: 1,
-    })
-
-    return (res.posts[0]?.content as any)?.scores
+    return fetchAndCache(
+      `${apiServer}/api/v0/posts.json?types=aleph-scoring-scores&addresses=${scoringAddress}&pagination=1&page=1`,
+      'scores',
+      1000 * 60,
+      (content: any) =>
+        content?.posts?.[0]?.content?.scores ?? { ccn: [], crn: [] },
+    )
   }
 
   protected async getMetrics(): Promise<{
     ccn: CCNMetrics[]
     crn: CRNMetrics[]
   }> {
-    const res = await this.sdkClient.getPosts({
-      types: 'aleph-network-metrics',
-      addresses: [metricAddress],
-      pagination: 1,
-      page: 1,
-    })
-
-    return (res.posts[0]?.content as any)?.metrics
-  }
-
-  protected async getCCNScores(): Promise<CCNScore[]> {
-    const res = await this.getScores()
-    return res.ccn
-  }
-
-  protected async getCCNMetrics(): Promise<CCNMetrics[]> {
-    const res = await this.getMetrics()
-    return res.ccn
-  }
-
-  protected async getCRNScores(): Promise<CRNScore[]> {
-    const res = await this.getScores()
-    return res.crn
-  }
-
-  protected async getCRNMetrics(): Promise<CRNMetrics[]> {
-    const res = await this.getMetrics()
-    return res.crn
+    return fetchAndCache(
+      `${apiServer}/api/v0/posts.json?types=aleph-network-metrics&addresses=${metricAddress}&pagination=1&page=1`,
+      'metrics',
+      1000 * 60,
+      (content: any) =>
+        content?.posts?.[0]?.content?.metrics ?? { ccn: [], crn: [] },
+    )
   }
 }


### PR DESCRIPTION
  Fetch scoring and metrics posts once in parallel with caching, source CRN
  resource totals from the crns.json list instead of per-node requests, and
  point scoringAddress at the account that publishes duplicate_ip.