### PR TITLE
feat: show Change CRN button on auto-selected node for instances

### DIFF
--- a/src/components/pages/console/instance/NewInstancePage/cmp.tsx
+++ b/src/components/pages/console/instance/NewInstancePage/cmp.tsx
@@ -188,6 +188,22 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                         <NodeScore score={node.score} />
                       </div>
                     </div>
+                    <ButtonWithInfoTooltip
+                      ref={manuallySelectButtonRef}
+                      type="button"
+                      kind="functional"
+                      variant="warning"
+                      size="md"
+                      onClick={handleManuallySelectCRN}
+                      disabled={manuallySelectCRNDisabled}
+                      tooltipContent={manuallySelectCRNDisabledMessage}
+                      tooltipPosition={{
+                        my: 'bottom-right',
+                        at: 'top-center',
+                      }}
+                    >
+                      Change CRN
+                    </ButtonWithInfoTooltip>
                   </div>
                 </NoisyContainer>
               )}


### PR DESCRIPTION
## What

Adds a visible **Change CRN** button to the New Instance page, next to the auto-selected CRN in Section 1. Clicking it opens the existing CRN list modal so the user can override the host the network picked for them.

Scope: normal instances only.

## Why

The manual-select control already existed but was effectively unreachable:
- The "Manually select CRN" button was gated by `{!node && ...}`, so it disappeared as soon as a CRN was auto-selected (i.e. always).
- It only lived inside the collapsed *Custom Node Selection* advanced toggle.

This surfaces the action in the always-visible auto-selected CRN box. It reuses the existing handlers (`handleManuallySelectCRN`), the `CRNList` modal, and the `manualNodeOverride` precedence logic — no new state or flow. The button respects the existing disabled/tooltip state when no wallet is connected.

## Verification

- `npm run lint` — clean
- `npm run build` — compiles successfully