### PR TITLE
feat: reserve CRN resources before creating an instance

### DIFF
--- a/src/components/pages/console/instance/NewInstancePage/cmp.tsx
+++ b/src/components/pages/console/instance/NewInstancePage/cmp.tsx
@@ -26,6 +26,7 @@ import CheckoutSummary from '@/components/form/CheckoutSummary'
 import { EntityDomainType, EntityType } from '@/helpers/constants'
 import { useSettings } from '@/hooks/common/useSettings'
 import { CenteredContainer } from '@/components/common/CenteredContainer'
+import { RotatingLines } from 'react-loader-spinner'
 import { useNewInstancePage } from './hook'
 import Form from '@/components/form/Form'
 import SwitchToggleContainer from '@/components/common/SwitchToggleContainer'
@@ -65,6 +66,7 @@ export default function NewInstancePage({ mainRef }: PageProps) {
     shouldRequestTermsAndConditions,
     aggregatedSpecs,
     compatibleNodesCount,
+    reservation,
     handleManuallySelectCRN,
     handleSelectNode,
     handleSubmit,
@@ -204,6 +206,38 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                     >
                       Change CRN
                     </ButtonWithInfoTooltip>
+                  </div>
+                </NoisyContainer>
+              )}
+
+              {/* CRN capacity reservation status */}
+              {reservation.status === 'checking' && (
+                <div tw="mt-4 flex items-center gap-3">
+                  <RotatingLines strokeColor="grey" width="1rem" />
+                  <p className="tp-body2" tw="opacity-70">
+                    Checking CRN capacity for the selected resources…
+                  </p>
+                </div>
+              )}
+              {reservation.status === 'failed' && reservation.error && (
+                <NoisyContainer tw="mt-4">
+                  <div tw="flex items-start gap-3">
+                    <Icon
+                      name="warning"
+                      tw="text-red-500 flex-shrink-0 mt-0.5"
+                    />
+                    <p className="tp-body2">{reservation.error}</p>
+                  </div>
+                </NoisyContainer>
+              )}
+              {reservation.status === 'reserved' && reservation.warning && (
+                <NoisyContainer tw="mt-4">
+                  <div tw="flex items-start gap-3">
+                    <Icon
+                      name="warning"
+                      tw="text-orange-500 flex-shrink-0 mt-0.5"
+                    />
+                    <p className="tp-body2">{reservation.warning}</p>
                   </div>
                 </NoisyContainer>
               )}

--- a/src/components/pages/console/instance/NewInstancePage/hook.ts
+++ b/src/components/pages/console/instance/NewInstancePage/hook.ts
@@ -75,6 +75,20 @@ export type NewInstanceFormState = NameAndTagsField & {
 
 export type Modal = 'node-list' | 'terms-and-conditions'
 
+export type CRNReservationStatus = 'idle' | 'checking' | 'reserved' | 'failed'
+
+export type CRNReservationState = {
+  status: CRNReservationStatus
+  /** Hash of the node the current reservation result refers to. */
+  nodeHash?: string
+  /** Specs signature the reservation was made for; invalidated when it changes. */
+  specsKey?: string
+  /** Set when no compatible CRN could fit the selected resources. */
+  error?: string
+  /** Set when a manually selected CRN was at capacity and got switched. */
+  warning?: string
+}
+
 export type UseNewInstancePageReturn = {
   address: string
   accountCreditBalance: number
@@ -100,6 +114,7 @@ export type UseNewInstancePageReturn = {
   aggregatedSpecs?: AggregatedNodeSpecs
   compatibleNodesCount: number
   manualNodeOverride: boolean
+  reservation: CRNReservationState
   handleManuallySelectCRN: () => void
   handleSelectNode: () => void
   handleRequestTermsAndConditionsAgreement: () => void
@@ -128,6 +143,9 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   const [selectedModal, setSelectedModal] = useState<Modal>()
   const [manualNodeOverride, setManualNodeOverride] = useState(false)
   const [manuallySelectedNode, setManuallySelectedNode] = useState<CRNSpecs>()
+  const [reservation, setReservation] = useState<CRNReservationState>({
+    status: 'idle',
+  })
 
   // -------------------------
   // Request CRNs specs and aggregated specs
@@ -259,11 +277,12 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     : ''
   const stableSpecs = useStableValue(formValues.specs, specsKey)
 
-  const { autoSelectedNode, compatibleNodesCount } = useAutoSelectNode({
-    selectedSpecs: stableSpecs,
-    validNodes,
-    enabled: !manualNodeOverride,
-  })
+  const { autoSelectedNode, compatibleNodes, compatibleNodesCount } =
+    useAutoSelectNode({
+      selectedSpecs: stableSpecs,
+      validNodes,
+      enabled: !manualNodeOverride,
+    })
 
   // Final node: manual override takes precedence over auto-selected
   const node: CRNSpecs | undefined = useMemo(() => {
@@ -279,6 +298,92 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
     return specs[node.hash]?.data
   }, [specs, node])
+
+  // -------------------------
+  // CRN resource reservation (pre-flight capacity check)
+
+  const buildAddInstance = useCallback(
+    (candidate: CRNSpecs): AddInstance =>
+      ({
+        ...formValues,
+        payment: {
+          chain: blockchain,
+          type: PaymentMethod.Credit,
+        },
+        node: candidate,
+      }) as AddInstance,
+    [formValues, blockchain],
+  )
+
+  // Reserves resources on `preferredNode`; if it cannot fit the specs, falls
+  // back to the next compatible node (highest score first). When a manually
+  // selected node gets switched, surfaces a warning. Returns the node that the
+  // CRN actually reserved, or undefined when none has capacity.
+  const resolveReservation = useCallback(
+    async (
+      preferredNode: CRNSpecs,
+      isManual: boolean,
+    ): Promise<CRNSpecs | undefined> => {
+      if (!manager) return undefined
+
+      setReservation({
+        status: 'checking',
+        nodeHash: preferredNode.hash,
+        specsKey,
+      })
+
+      // One wallet signature, cached for the per-node reservations below.
+      try {
+        await manager.ensureAuthToken()
+      } catch (e) {
+        setReservation({
+          status: 'failed',
+          nodeHash: preferredNode.hash,
+          specsKey,
+          error: (e as Error).message,
+        })
+        return undefined
+      }
+
+      const candidates = [
+        preferredNode,
+        ...compatibleNodes.filter((n) => n.hash !== preferredNode.hash),
+      ]
+
+      for (const candidate of candidates) {
+        const { reserved } = await manager.reserveResourcesForNode(
+          buildAddInstance(candidate),
+        )
+        if (!reserved) continue
+
+        const switched = candidate.hash !== preferredNode.hash
+        if (switched) {
+          setManualNodeOverride(true)
+          setManuallySelectedNode(candidate)
+        }
+
+        setReservation({
+          status: 'reserved',
+          nodeHash: candidate.hash,
+          specsKey,
+          warning:
+            switched && isManual
+              ? 'The CRN you selected could not fit the selected resources. A compatible node was selected instead — review and create.'
+              : undefined,
+        })
+        return candidate
+      }
+
+      setReservation({
+        status: 'failed',
+        nodeHash: preferredNode.hash,
+        specsKey,
+        error: 'No compatible CRN has enough free resources right now.',
+      })
+      return undefined
+    },
+    [manager, specsKey, compatibleNodes, buildAddInstance],
+  )
 
   // -------------------------
   // Terms and conditions
@@ -393,7 +498,11 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     // Set manual override and the selected node
     setManualNodeOverride(true)
     setManuallySelectedNode(selectedNode)
-  }, [selectedNode])
+
+    // Reserve right away so the user learns immediately if the chosen CRN
+    // cannot fit the selected resources.
+    await resolveReservation(selectedNode, true)
+  }, [selectedNode, resolveReservation])
 
   const handleManuallySelectCRN = useCallback(() => {
     setSelectedModal('node-list')
@@ -427,10 +536,34 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
   // Handle submit
   const handleFormSubmit = useCallback(
-    (e: FormEvent) => {
-      return handleSubmit(e)
+    async (e: FormEvent) => {
+      e.preventDefault()
+      if (!node) return
+
+      // Before signing, make sure the resources are reserved on the current
+      // node for the current specs. If they already are, create straight away.
+      const reservedForCurrent =
+        reservation.status === 'reserved' &&
+        reservation.nodeHash === node.hash &&
+        reservation.specsKey === specsKey
+
+      if (reservedForCurrent) return handleSubmit(e)
+
+      const reservedNode = await resolveReservation(node, manualNodeOverride)
+      if (!reservedNode) return
+
+      // Same node reserved → safe to create now. If it was switched, the new
+      // node is pinned and the next Create click submits against it.
+      if (reservedNode.hash === node.hash) return handleSubmit(e)
     },
-    [handleSubmit],
+    [
+      node,
+      reservation,
+      specsKey,
+      manualNodeOverride,
+      resolveReservation,
+      handleSubmit,
+    ],
   )
 
   // -------------------------
@@ -462,13 +595,15 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   useEffect(() => {
     if (!formValues.specs || !prevSpecs) return
 
-    // If tier changed, reset manual override so auto-select kicks in
+    // If tier changed, reset manual override so auto-select kicks in, and drop
+    // any reservation since it was made for the previous specs.
     if (
       formValues.specs.cpu !== prevSpecs.cpu ||
       formValues.specs.ram !== prevSpecs.ram
     ) {
       setManualNodeOverride(false)
       setManuallySelectedNode(undefined)
+      setReservation({ status: 'idle' })
     }
   }, [formValues.specs, prevSpecs])
 
@@ -497,6 +632,7 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     aggregatedSpecs,
     compatibleNodesCount,
     manualNodeOverride,
+    reservation,
     handleManuallySelectCRN,
     handleSelectNode,
     handleSubmit: handleFormSubmit,

--- a/src/components/pages/console/instance/NewInstancePage/hook.ts
+++ b/src/components/pages/console/instance/NewInstancePage/hook.ts
@@ -1,5 +1,12 @@
 import { useAppState } from '@/contexts/appState'
-import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import Router, { useRouter } from 'next/router'
 import { useForm } from '@/hooks/common/useForm'
 import {
@@ -146,6 +153,10 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   const [reservation, setReservation] = useState<CRNReservationState>({
     status: 'idle',
   })
+  // Prevents overlapping reservation requests (concurrent Create clicks).
+  const reservingRef = useRef(false)
+  // Invalidates in-flight reservations when the specs/tier change.
+  const reservationGenRef = useRef(0)
 
   // -------------------------
   // Request CRNs specs and aggregated specs
@@ -325,62 +336,78 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
       isManual: boolean,
     ): Promise<CRNSpecs | undefined> => {
       if (!manager) return undefined
+      // Ignore overlapping requests so concurrent clicks don't reserve on
+      // several nodes at once.
+      if (reservingRef.current) return undefined
 
-      setReservation({
-        status: 'checking',
-        nodeHash: preferredNode.hash,
-        specsKey,
-      })
+      reservingRef.current = true
+      // Anything started under a previous generation (e.g. before a tier
+      // change) is stale and must not write state or pin a node.
+      const gen = ++reservationGenRef.current
+      const isStale = () => reservationGenRef.current !== gen
 
-      // One wallet signature, cached for the per-node reservations below.
       try {
-        await manager.ensureAuthToken()
-      } catch (e) {
         setReservation({
-          status: 'failed',
+          status: 'checking',
           nodeHash: preferredNode.hash,
           specsKey,
-          error: (e as Error).message,
         })
-        return undefined
-      }
 
-      const candidates = [
-        preferredNode,
-        ...compatibleNodes.filter((n) => n.hash !== preferredNode.hash),
-      ]
-
-      for (const candidate of candidates) {
-        const { reserved } = await manager.reserveResourcesForNode(
-          buildAddInstance(candidate),
-        )
-        if (!reserved) continue
-
-        const switched = candidate.hash !== preferredNode.hash
-        if (switched) {
-          setManualNodeOverride(true)
-          setManuallySelectedNode(candidate)
+        // One wallet signature, cached for the per-node reservations below.
+        try {
+          await manager.ensureAuthToken()
+        } catch (e) {
+          if (!isStale())
+            setReservation({
+              status: 'failed',
+              nodeHash: preferredNode.hash,
+              specsKey,
+              error: (e as Error).message,
+            })
+          return undefined
         }
 
-        setReservation({
-          status: 'reserved',
-          nodeHash: candidate.hash,
-          specsKey,
-          warning:
-            switched && isManual
-              ? 'The CRN you selected could not fit the selected resources. A compatible node was selected instead — review and create.'
-              : undefined,
-        })
-        return candidate
-      }
+        const candidates = [
+          preferredNode,
+          ...compatibleNodes.filter((n) => n.hash !== preferredNode.hash),
+        ]
 
-      setReservation({
-        status: 'failed',
-        nodeHash: preferredNode.hash,
-        specsKey,
-        error: 'No compatible CRN has enough free resources right now.',
-      })
-      return undefined
+        for (const candidate of candidates) {
+          const { reserved } = await manager.reserveResourcesForNode(
+            buildAddInstance(candidate),
+          )
+          if (isStale()) return undefined
+          if (!reserved) continue
+
+          const switched = candidate.hash !== preferredNode.hash
+          if (switched) {
+            setManualNodeOverride(true)
+            setManuallySelectedNode(candidate)
+          }
+
+          setReservation({
+            status: 'reserved',
+            nodeHash: candidate.hash,
+            specsKey,
+            warning:
+              switched && isManual
+                ? 'The CRN you selected could not fit the selected resources. A compatible node was selected instead — review and create.'
+                : undefined,
+          })
+          return candidate
+        }
+
+        if (!isStale())
+          setReservation({
+            status: 'failed',
+            nodeHash: preferredNode.hash,
+            specsKey,
+            error: 'No compatible CRN has enough free resources right now.',
+          })
+        return undefined
+      } finally {
+        reservingRef.current = false
+      }
     },
     [manager, specsKey, compatibleNodes, buildAddInstance],
   )
@@ -484,8 +511,15 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     if (!account) return true
     if (isDisabledDueToInsufficientFunds) return true
     if (!hasEnoughBalance) return true
+    // Avoid overlapping reservations from repeated clicks.
+    if (reservation.status === 'checking') return true
     return false
-  }, [account, isDisabledDueToInsufficientFunds, hasEnoughBalance])
+  }, [
+    account,
+    isDisabledDueToInsufficientFunds,
+    hasEnoughBalance,
+    reservation.status,
+  ])
 
   // -------------------------
   // Handlers
@@ -522,19 +556,11 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
       : setValue('termsAndConditions', node?.terms_and_conditions)
   }, [formValues.termsAndConditions, node, setValue])
 
-  const handleAcceptTermsAndConditions = useCallback(
-    (e: React.FormEvent) => {
-      handleCloseModal()
-      handleSubmit(e)
-    },
-    [handleCloseModal, handleSubmit],
-  )
-
   const handleBack = () => {
     router.push('.')
   }
 
-  // Handle submit
+  // Handle submit: reserve CRN capacity before signing (see resolveReservation).
   const handleFormSubmit = useCallback(
     async (e: FormEvent) => {
       e.preventDefault()
@@ -564,6 +590,15 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
       resolveReservation,
       handleSubmit,
     ],
+  )
+
+  // T&C-gated nodes must run the same reservation check before signing.
+  const handleAcceptTermsAndConditions = useCallback(
+    (e: React.FormEvent) => {
+      handleCloseModal()
+      handleFormSubmit(e)
+    },
+    [handleCloseModal, handleFormSubmit],
   )
 
   // -------------------------
@@ -603,6 +638,8 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     ) {
       setManualNodeOverride(false)
       setManuallySelectedNode(undefined)
+      // Invalidate any in-flight reservation so its result is discarded.
+      reservationGenRef.current++
       setReservation({ status: 'idle' })
     }
   }, [formValues.specs, prevSpecs])

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -194,6 +194,11 @@ export type StreamPaymentDetails = {
   streams: StreamPaymentDetail[]
 }
 
+export type ReserveCRNResourcesResult = {
+  reserved: boolean
+  error?: string
+}
+
 export abstract class ExecutableManager<T extends Executable> {
   protected static cachedPubKeyToken?: AuthPubKeyToken
 
@@ -373,32 +378,40 @@ export abstract class ExecutableManager<T extends Executable> {
     }
   }
 
+  /**
+   * Pre-allocates (locks) the requested resources on a CRN by calling its
+   * `/control/reserve_resources` endpoint. The CRN holds the reservation for a
+   * short window, so this doubles as a capacity check before the instance
+   * message is signed: a `reserved` status means the node can fit the specs.
+   *
+   * Returns a result instead of throwing so callers can fall back to another
+   * node when a CRN cannot fit the selected resources. Signature/auth errors
+   * are surfaced via `error` as well.
+   */
   async reserveCRNResources(
     node: CRN,
     instanceConfig: InstancePublishConfiguration,
-  ): Promise<void> {
-    if (!node.address) throw Err.InvalidCRNAddress
-
-    const nodeUrl = NodeManager.normalizeUrl(node.address)
-    const url = new URL(`${nodeUrl}/control/reserve_resources`)
-    const { hostname: domain, pathname: path } = url
-
-    const { keyPair, pubKeyHeader } = await this.getAuthPubKeyToken()
-
-    const signedOperationToken = await this.getAuthOperationToken(
-      keyPair.privateKey,
-      domain,
-      path,
-    )
-
-    const message =
-      await this.sdkClient.instanceClient.getCostComputableMessage(
-        instanceConfig,
-      )
-
-    let errorMsg = ''
+  ): Promise<ReserveCRNResourcesResult> {
+    if (!node.address) return { reserved: false, error: 'Invalid CRN address' }
 
     try {
+      const nodeUrl = NodeManager.normalizeUrl(node.address)
+      const url = new URL(`${nodeUrl}/control/reserve_resources`)
+      const { hostname: domain, pathname: path } = url
+
+      const { keyPair, pubKeyHeader } = await this.getAuthPubKeyToken()
+
+      const signedOperationToken = await this.getAuthOperationToken(
+        keyPair.privateKey,
+        domain,
+        path,
+      )
+
+      const message =
+        await this.sdkClient.instanceClient.getCostComputableMessage(
+          instanceConfig,
+        )
+
       const req = await fetch(url.toString(), {
         method: 'POST',
         headers: {
@@ -412,17 +425,27 @@ export abstract class ExecutableManager<T extends Executable> {
 
       const resp = await req.json()
 
-      /*
-        expires: "2025-03-28 11:21:21.744592+00:00"
-        status: "reserved"
-      */
-      if (resp.status === 'reserved') return
-      // errorMsg = resp.errors[instanceId]
-    } catch (e) {
-      errorMsg = (e as Error).message
-    }
+      // resp on success: { status: 'reserved', expires: '<iso timestamp>' }
+      if (resp.status === 'reserved') return { reserved: true }
 
-    throw Err.InstanceStartupFailed(node.hash, errorMsg)
+      const error =
+        resp.error ||
+        resp.errors?.[node.hash] ||
+        'CRN cannot fit the selected resources'
+
+      return { reserved: false, error }
+    } catch (e) {
+      return { reserved: false, error: (e as Error).message }
+    }
+  }
+
+  /**
+   * Warms the cached wallet-signed pubkey token (one wallet signature). Call
+   * this once before reserving across several candidate nodes so the per-node
+   * reservations reuse the cache instead of prompting the wallet repeatedly.
+   */
+  async ensureAuthToken(): Promise<void> {
+    await this.getAuthPubKeyToken()
   }
 
   async notifyCRNAllocation(

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -428,9 +428,14 @@ export abstract class ExecutableManager<T extends Executable> {
       // resp on success: { status: 'reserved', expires: '<iso timestamp>' }
       if (resp.status === 'reserved') return { reserved: true }
 
+      // The endpoint's error shape isn't documented, so surface any message it
+      // provides regardless of key, falling back to a generic one.
       const error =
         resp.error ||
-        resp.errors?.[node.hash] ||
+        resp.detail ||
+        (resp.errors && typeof resp.errors === 'object'
+          ? String(Object.values(resp.errors)[0] ?? '')
+          : '') ||
         'CRN cannot fit the selected resources'
 
       return { reserved: false, error }

--- a/src/domain/instance.ts
+++ b/src/domain/instance.ts
@@ -24,6 +24,7 @@ import {
   ExecutableStatus,
   StreamPaymentDetails,
   StreamPaymentDetail,
+  ReserveCRNResourcesResult,
 } from './executable'
 import {
   InstanceSystemVolumeField,
@@ -574,7 +575,28 @@ export class InstanceManager<T extends InstanceEntity = Instance>
     if (!newInstance.node || !newInstance.node.address) throw Err.InvalidNode
 
     yield
-    await this.reserveCRNResources(newInstance.node, instanceMessage)
+    const { reserved, error } = await this.reserveCRNResources(
+      newInstance.node,
+      instanceMessage,
+    )
+    if (!reserved)
+      throw Err.InstanceStartupFailed(newInstance.node.hash, error || '')
+  }
+
+  /**
+   * Reserves the resources for `newInstance` on its currently selected CRN as a
+   * pre-flight capacity check, building the publish config from the form values.
+   * Returns whether the node can fit the specs so the caller can fall back to
+   * another node or block the create.
+   */
+  async reserveResourcesForNode(
+    newInstance: AddInstance,
+  ): Promise<ReserveCRNResourcesResult> {
+    if (!newInstance.node?.address)
+      return { reserved: false, error: 'Invalid CRN' }
+
+    const config = await this.parseInstanceForCostEstimation(newInstance)
+    return this.reserveCRNResources(newInstance.node, config)
   }
 
   protected async *addPAYGAllocationSteps(


### PR DESCRIPTION
## What

Adds a CRN capacity pre-check to instance creation so an instance is never signed against a CRN that cannot fit the selected resources. Scope: normal instances.

## Why

Today the reservation call is commented out, so instances are created with no capacity check. Sometimes the message is signed but the selected CRN has no free resources and the instance fails to start. This reserves (locks) the resources on the CRN first — the node holds them for a short window — and only proceeds when the CRN confirms it can fit the specs.

## How

**Domain**
- `reserveCRNResources()` now returns `{ reserved, error }` instead of throwing. It POSTs the signed instance config to the CRN `/control/reserve_resources` endpoint and treats `status: "reserved"` as success.
- `ensureAuthToken()` warms the wallet-signed token once so checking several candidate nodes does not prompt the wallet repeatedly.
- `InstanceManager.reserveResourcesForNode()` builds the publish config from the form values and reserves.

**Flow (NewInstancePage hook)**
- On manual CRN change → reserve immediately.
- Before signing (Create) → if the current node+specs is already reserved, create directly; otherwise reserve first.
- On failure, auto-retry the next compatible node (highest score first). If a manually selected node is switched, surface a warning; auto switches silently. Reservation is invalidated when the tier changes.
- When a reservation switches the node, the new node is pinned and the create stops for a confirm click, so signing never happens against a stale node.

**UI**
- Status under the CRN box: checking (spinner), error when no compatible CRN has capacity, warning when a manually chosen CRN was switched.

## Verification

- `npm run lint` — clean
- `npm run build` — compiles successfully

Not yet verified in-browser against a live CRN.