### PR TITLE
fix: use hold tier for node picture uploads

### DIFF
--- a/src/domain/file.ts
+++ b/src/domain/file.ts
@@ -14,6 +14,7 @@ import {
 import {
   ItemType,
   MessageType,
+  Payment,
   PaymentType,
   StoreMessage,
 } from '@aleph-sdk/message'
@@ -195,6 +196,7 @@ export class FileManager {
     storageEngine: Parameters<
       AuthenticatedAlephHttpClient['createStore']
     >[0]['storageEngine'] = ItemType.storage,
+    payment: Payment = { chain: Blockchain.ETH, type: PaymentType.credit },
   ): Promise<
     StoreMessage & { contentItemHash: string; messageItemHash: string }
   > {
@@ -214,7 +216,7 @@ export class FileManager {
         name: fileObject.name,
         format: fileObject.type,
       },
-      payment: { chain: Blockchain.ETH, type: PaymentType.credit },
+      payment,
     })
 
     // Create a properly typed object including both message properties and our additional fields

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -14,7 +14,13 @@ import {
   AlephHttpClient,
   AuthenticatedAlephHttpClient,
 } from '@aleph-sdk/client'
-import { AggregateMessage, ItemType } from '@aleph-sdk/message'
+import {
+  AggregateMessage,
+  ItemType,
+  Payment,
+  PaymentType,
+} from '@aleph-sdk/message'
+import { Blockchain } from '@aleph-sdk/core'
 import {
   extractValidEthAddress,
   fetchAndCache,
@@ -824,9 +830,16 @@ export class NodeManager {
       details.registration_url = ''
     }
 
+    const holdPayment: Payment = {
+      chain: Blockchain.ETH,
+      type: PaymentType.hold,
+    }
+
     if (details.picture instanceof File) {
       const { contentItemHash } = await this.fileManager.uploadFile(
         details.picture,
+        ItemType.storage,
+        holdPayment,
       )
       details.picture = contentItemHash
     }
@@ -834,6 +847,8 @@ export class NodeManager {
     if (details.banner instanceof File) {
       const { contentItemHash } = await this.fileManager.uploadFile(
         details.banner,
+        ItemType.storage,
+        holdPayment,
       )
       details.banner = contentItemHash
     }
@@ -844,6 +859,8 @@ export class NodeManager {
     ) {
       const { messageItemHash } = await this.fileManager.uploadFile(
         details.terms_and_conditions,
+        ItemType.storage,
+        holdPayment,
       )
       details.terms_and_conditions = messageItemHash
     }


### PR DESCRIPTION
Node picture, banner, and terms uploads were billed to credits because `uploadFile` hardcoded a credit payment. Adds an optional `payment` parameter to `uploadFile` (defaulting to credit) and passes a hold-tier payment for the three node uploads.