### PR TITLE
feat: skip fixed CRN by default and resolve allocation via scheduler

### DIFF
--- a/src/components/common/entityData/EntityPortForwarding/hook.ts
+++ b/src/components/common/entityData/EntityPortForwarding/hook.ts
@@ -51,7 +51,7 @@ function useCRNNotification(
 
     try {
       const nodeUrl = NodeManager.normalizeUrl(
-        executableStatus.node.address || '',
+        executableStatus.node?.address || '',
       )
       if (!nodeUrl) return
 
@@ -261,7 +261,7 @@ function usePortPolling(
         await notifyCRNUpdate?.()
 
         const nodeUrl = NodeManager.normalizeUrl(
-          executableStatus.node.address || '',
+          executableStatus.node?.address || '',
         )
         if (!nodeUrl) return
 

--- a/src/components/pages/console/gpuInstance/NewGpuInstancePage/hook.ts
+++ b/src/components/pages/console/gpuInstance/NewGpuInstancePage/hook.ts
@@ -18,6 +18,7 @@ import {
 import { InstanceSpecsField } from '@/hooks/form/useSelectInstanceSpecs'
 import { DomainField } from '@/hooks/form/useAddDomains'
 import { AddInstance } from '@/domain/instance'
+import { gpuInstanceSchema } from '@/helpers/schemas/instance'
 import { Control, FieldErrors, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { EntityType, NAVIGATION_URLS, PaymentMethod } from '@/helpers/constants'
@@ -47,7 +48,6 @@ import useFetchTermsAndConditions, {
 } from '@/hooks/common/useFetchTermsAndConditions'
 import { useDefaultTiers } from '@/hooks/common/pricing/useDefaultTiers'
 import { useGpuInstanceManager } from '@/hooks/common/useManager/useGpuInstanceManager'
-import { GpuInstanceManager } from '@/domain/gpuInstance'
 import usePrevious from '@/hooks/common/usePrevious'
 import { useCanAfford } from '@/hooks/common/useCanAfford'
 import {
@@ -251,7 +251,7 @@ export function useNewGpuInstancePage(): UseNewGpuInstancePageReturn {
   } = useForm({
     defaultValues,
     onSubmit: (state: NewGpuInstanceFormState) => onSubmit(state, node),
-    resolver: zodResolver(GpuInstanceManager.addSchema),
+    resolver: zodResolver(gpuInstanceSchema),
     readyDeps: [],
   })
 

--- a/src/components/pages/console/instance/NewInstancePage/cmp.tsx
+++ b/src/components/pages/console/instance/NewInstancePage/cmp.tsx
@@ -152,9 +152,8 @@ export default function NewInstancePage({ mainRef }: PageProps) {
             </CompositeSectionTitle>
             <p>
               Please select one of the available instance tiers as a base for
-              your VM. A compatible CRN node will be automatically selected for
-              you based on your tier choice. You can customize the node
-              selection in the advanced options below.
+              your VM. By default the network assigns a compatible CRN node for
+              you. You can pick a specific node in the advanced options below.
             </p>
 
             <div tw="px-0 my-6 relative">
@@ -168,79 +167,6 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                 aggregatedSpecs={aggregatedSpecs}
                 showOpenClawSpotlight
               />
-
-              {/* Auto-selected node info */}
-              {node && (
-                <NoisyContainer tw="mt-6">
-                  <div tw="flex items-center gap-4">
-                    <Icon name="server" size="lg" tw="opacity-60" />
-                    <div tw="flex-1">
-                      <p className="tp-body2" tw="opacity-60 mb-1">
-                        Auto-selected CRN ({compatibleNodesCount} compatible
-                        nodes)
-                      </p>
-                      <div tw="flex items-center gap-4">
-                        <NodeName
-                          hash={node.hash}
-                          name={node.name}
-                          picture={node.picture}
-                          ImageCmp={Image}
-                          apiServer={apiServer}
-                        />
-                        <NodeScore score={node.score} />
-                      </div>
-                    </div>
-                    <ButtonWithInfoTooltip
-                      ref={manuallySelectButtonRef}
-                      type="button"
-                      kind="functional"
-                      variant="warning"
-                      size="md"
-                      onClick={handleManuallySelectCRN}
-                      disabled={manuallySelectCRNDisabled}
-                      tooltipContent={manuallySelectCRNDisabledMessage}
-                      tooltipPosition={{
-                        my: 'bottom-right',
-                        at: 'top-center',
-                      }}
-                    >
-                      Change CRN
-                    </ButtonWithInfoTooltip>
-                  </div>
-                </NoisyContainer>
-              )}
-
-              {/* CRN capacity reservation status */}
-              {reservation.status === 'checking' && (
-                <div tw="mt-4 flex items-center gap-3">
-                  <RotatingLines strokeColor="grey" width="1rem" />
-                  <p className="tp-body2" tw="opacity-70">
-                    Checking CRN capacity for the selected resources…
-                  </p>
-                </div>
-              )}
-              {reservation.status === 'failed' && reservation.error && (
-                <NoisyContainer tw="mt-4">
-                  <div tw="flex items-start gap-3">
-                    <Icon
-                      name="warning"
-                      tw="text-red-500 flex-shrink-0 mt-0.5"
-                    />
-                    <p className="tp-body2">{reservation.error}</p>
-                  </div>
-                </NoisyContainer>
-              )}
-              {reservation.status === 'reserved' && reservation.warning && (
-                <NoisyContainer tw="mt-4">
-                  <div tw="flex items-start gap-3">
-                    <Icon
-                      name="warning"
-                      tw="text-orange-500 flex-shrink-0 mt-0.5"
-                    />
-                    <p className="tp-body2">{reservation.warning}</p>
-                  </div>
-                </NoisyContainer>
-              )}
             </div>
           </CenteredContainer>
         </section>
@@ -338,9 +264,9 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                     CRN Node Selection
                   </TextGradient>
                   <p tw="mb-6">
-                    By default, the best performing CRN node compatible with
-                    your selected tier is automatically chosen. You can manually
-                    select a different node below if needed.
+                    By default, the network automatically assigns a compatible
+                    CRN node for your selected tier. You can manually select a
+                    specific node below if needed.
                   </p>
                   <div tw="px-0 mb-6 min-h-[6rem] relative">
                     <NoisyContainer>
@@ -369,6 +295,35 @@ export default function NewInstancePage({ mainRef }: PageProps) {
                           </ButtonWithInfoTooltip>
                         )}
                       </div>
+
+                      {/* CRN capacity reservation status */}
+                      {reservation.status === 'checking' && (
+                        <div tw="mt-4 flex items-center gap-3">
+                          <RotatingLines strokeColor="grey" width="1rem" />
+                          <p className="tp-body2" tw="opacity-70">
+                            Checking CRN capacity for the selected resources…
+                          </p>
+                        </div>
+                      )}
+                      {reservation.status === 'failed' && reservation.error && (
+                        <div tw="mt-4 flex items-start gap-3">
+                          <Icon
+                            name="warning"
+                            tw="text-red-500 flex-shrink-0 mt-0.5"
+                          />
+                          <p className="tp-body2">{reservation.error}</p>
+                        </div>
+                      )}
+                      {reservation.status === 'reserved' &&
+                        reservation.warning && (
+                          <div tw="mt-4 flex items-start gap-3">
+                            <Icon
+                              name="warning"
+                              tw="text-orange-500 flex-shrink-0 mt-0.5"
+                            />
+                            <p className="tp-body2">{reservation.warning}</p>
+                          </div>
+                        )}
                     </NoisyContainer>
                   </div>
                 </SwitchToggleContainer>

--- a/src/components/pages/console/instance/NewInstancePage/hook.ts
+++ b/src/components/pages/console/instance/NewInstancePage/hook.ts
@@ -120,7 +120,6 @@ export type UseNewInstancePageReturn = {
   shouldRequestTermsAndConditions: boolean
   aggregatedSpecs?: AggregatedNodeSpecs
   compatibleNodesCount: number
-  manualNodeOverride: boolean
   reservation: CRNReservationState
   handleManuallySelectCRN: () => void
   handleSelectNode: () => void
@@ -148,7 +147,6 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
   const [selectedNode, setSelectedNode] = useState<CRNSpecs>()
   const [selectedModal, setSelectedModal] = useState<Modal>()
-  const [manualNodeOverride, setManualNodeOverride] = useState(false)
   const [manuallySelectedNode, setManuallySelectedNode] = useState<CRNSpecs>()
   const [reservation, setReservation] = useState<CRNReservationState>({
     status: 'idle',
@@ -194,14 +192,17 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     async (state: NewInstanceFormState, node: CRNSpecs | undefined) => {
       if (!manager) throw Err.ConnectYourWallet
       if (!account) throw Err.InvalidAccount
-      if (!node) throw Err.InvalidNode
 
-      const nodeSpecs = specs[node.hash]?.data
-      if (!nodeSpecs) throw Err.InvalidCRNSpecs
+      // A node is only present when manually selected; validate it against the
+      // tier. With no node the network assigns a compatible CRN server-side.
+      if (node) {
+        const nodeSpecs = specs[node.hash]?.data
+        if (!nodeSpecs) throw Err.InvalidCRNSpecs
 
-      const [minSpecs] = defaultTiers
-      const isValid = NodeManager.validateMinNodeSpecs(minSpecs, nodeSpecs)
-      if (!isValid) throw Err.InvalidCRNSpecs
+        const [minSpecs] = defaultTiers
+        const isValid = NodeManager.validateMinNodeSpecs(minSpecs, nodeSpecs)
+        if (!isValid) throw Err.InvalidCRNSpecs
+      }
 
       if (!blockchain) {
         handleConnect({ blockchain: BlockchainId.BASE })
@@ -288,20 +289,15 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     : ''
   const stableSpecs = useStableValue(formValues.specs, specsKey)
 
-  const { autoSelectedNode, compatibleNodes, compatibleNodesCount } =
-    useAutoSelectNode({
-      selectedSpecs: stableSpecs,
-      validNodes,
-      enabled: !manualNodeOverride,
-    })
+  const { compatibleNodes, compatibleNodesCount } = useAutoSelectNode({
+    selectedSpecs: stableSpecs,
+    validNodes,
+    enabled: false,
+  })
 
-  // Final node: manual override takes precedence over auto-selected
-  const node: CRNSpecs | undefined = useMemo(() => {
-    if (manualNodeOverride && manuallySelectedNode) {
-      return manuallySelectedNode
-    }
-    return autoSelectedNode
-  }, [manualNodeOverride, manuallySelectedNode, autoSelectedNode])
+  // The node is only set when the user manually selects a CRN in the advanced
+  // options; otherwise the network assigns it (no node_hash in the message).
+  const node: CRNSpecs | undefined = manuallySelectedNode
 
   const nodeSpecs = useMemo(() => {
     if (!node) return
@@ -331,10 +327,7 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   // selected node gets switched, surfaces a warning. Returns the node that the
   // CRN actually reserved, or undefined when none has capacity.
   const resolveReservation = useCallback(
-    async (
-      preferredNode: CRNSpecs,
-      isManual: boolean,
-    ): Promise<CRNSpecs | undefined> => {
+    async (preferredNode: CRNSpecs): Promise<CRNSpecs | undefined> => {
       if (!manager) return undefined
       // Ignore overlapping requests so concurrent clicks don't reserve on
       // several nodes at once.
@@ -381,7 +374,6 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
           const switched = candidate.hash !== preferredNode.hash
           if (switched) {
-            setManualNodeOverride(true)
             setManuallySelectedNode(candidate)
           }
 
@@ -389,10 +381,9 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
             status: 'reserved',
             nodeHash: candidate.hash,
             specsKey,
-            warning:
-              switched && isManual
-                ? 'The CRN you selected could not fit the selected resources. A compatible node was selected instead — review and create.'
-                : undefined,
+            warning: switched
+              ? 'The CRN you selected could not fit the selected resources. A compatible node was selected instead — review and create.'
+              : undefined,
           })
           return candidate
         }
@@ -529,13 +520,11 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
     if (!selectedNode) return
 
-    // Set manual override and the selected node
-    setManualNodeOverride(true)
     setManuallySelectedNode(selectedNode)
 
     // Reserve right away so the user learns immediately if the chosen CRN
     // cannot fit the selected resources.
-    await resolveReservation(selectedNode, true)
+    await resolveReservation(selectedNode)
   }, [selectedNode, resolveReservation])
 
   const handleManuallySelectCRN = useCallback(() => {
@@ -564,7 +553,10 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
   const handleFormSubmit = useCallback(
     async (e: FormEvent) => {
       e.preventDefault()
-      if (!node) return
+
+      // No manually selected CRN → the network assigns the node; nothing to
+      // reserve, create straight away.
+      if (!node) return handleSubmit(e)
 
       // Before signing, make sure the resources are reserved on the current
       // node for the current specs. If they already are, create straight away.
@@ -575,21 +567,14 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
 
       if (reservedForCurrent) return handleSubmit(e)
 
-      const reservedNode = await resolveReservation(node, manualNodeOverride)
+      const reservedNode = await resolveReservation(node)
       if (!reservedNode) return
 
       // Same node reserved → safe to create now. If it was switched, the new
       // node is pinned and the next Create click submits against it.
       if (reservedNode.hash === node.hash) return handleSubmit(e)
     },
-    [
-      node,
-      reservation,
-      specsKey,
-      manualNodeOverride,
-      resolveReservation,
-      handleSubmit,
-    ],
+    [node, reservation, specsKey, resolveReservation, handleSubmit],
   )
 
   // T&C-gated nodes must run the same reservation check before signing.
@@ -625,18 +610,17 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     setValue('nodeSpecs', stableNodeSpecs)
   }, [stableNodeSpecs, setValue])
 
-  // @note: Reset manual override when tier changes (user needs to re-select node)
+  // @note: Reset manual CRN selection when tier changes (user needs to re-select node)
   const prevSpecs = usePrevious(formValues.specs)
   useEffect(() => {
     if (!formValues.specs || !prevSpecs) return
 
-    // If tier changed, reset manual override so auto-select kicks in, and drop
-    // any reservation since it was made for the previous specs.
+    // If tier changed, drop any manual CRN selection and the reservation,
+    // since the reservation was made for the previous specs.
     if (
       formValues.specs.cpu !== prevSpecs.cpu ||
       formValues.specs.ram !== prevSpecs.ram
     ) {
-      setManualNodeOverride(false)
       setManuallySelectedNode(undefined)
       // Invalidate any in-flight reservation so its result is discarded.
       reservationGenRef.current++
@@ -668,7 +652,6 @@ export function useNewInstancePage(): UseNewInstancePageReturn {
     shouldRequestTermsAndConditions,
     aggregatedSpecs,
     compatibleNodesCount,
-    manualNodeOverride,
     reservation,
     handleManuallySelectCRN,
     handleSelectNode,

--- a/src/domain/executable.ts
+++ b/src/domain/executable.ts
@@ -49,6 +49,12 @@ import { withRetry } from '@/helpers/utils'
 import { SuperfluidAccount } from '@aleph-sdk/superfluid'
 import { CostLine } from './cost'
 import { BlockchainId } from './connect'
+import {
+  fetchSchedulerNode,
+  fetchSchedulerVm,
+  SchedulerVm,
+  SchedulerVmStatus,
+} from './scheduler'
 
 export type HoldPaymentConfiguration = {
   chain: BlockchainId
@@ -115,13 +121,20 @@ export type ExecutableCalculatedStatus =
   | 'running'
   | 'preparing'
 
+export type ExecutableSchedulerStatus = {
+  status: SchedulerVmStatus
+  allocatedAt?: string
+  migrationTarget?: string
+}
+
 export type ExecutableStatus = {
   version: 'v1' | 'v2'
   hash: string
   ipv4: string
   ipv6: string
   ipv6Parsed: string
-  node: CRN
+  node?: CRN
+  scheduler?: ExecutableSchedulerStatus
   // fields added from v2 request
   hostIpv4?: string
   ipv4Parsed?: string
@@ -202,6 +215,14 @@ export type ReserveCRNResourcesResult = {
 export abstract class ExecutableManager<T extends Executable> {
   protected static cachedPubKeyToken?: AuthPubKeyToken
 
+  // Scheduler allocations cached once a node is allocated, so status polling
+  // goes straight to the CRN afterwards. Entries are invalidated when the CRN
+  // stops answering or no longer lists the VM (e.g. after a migration).
+  // Note: cached entries freeze the scheduler status fields (status,
+  // migration_target) as of allocation time; CRN runtime data supersedes them
+  // once available, so do not read live scheduling state from the cache.
+  protected schedulerAllocations = new Map<string, SchedulerVm>()
+
   constructor(
     protected account: Account | undefined,
     protected volumeManager: VolumeManager,
@@ -225,20 +246,54 @@ export abstract class ExecutableManager<T extends Executable> {
   ): Promise<StreamPaymentDetails | undefined>
 
   async checkStatus(executable: T): Promise<ExecutableStatus | undefined> {
-    const node = await this.getAllocationCRN(executable)
-    if (!node) return
+    const schedulerVm = await this.getSchedulerVm(executable.id)
 
-    const { address } = node
-    if (!address) throw Err.InvalidCRNAddress
+    const node = schedulerVm?.allocated_node
+      ? await this.resolveCRNByHash(schedulerVm.allocated_node)
+      : await this.getAllocationCRNLegacy(executable)
 
-    const nodeUrl = NodeManager.normalizeUrl(address)
-
-    const { version, json: response } = await this.fetchExecutions(nodeUrl)
+    const scheduler: ExecutableSchedulerStatus | undefined = schedulerVm
+      ? {
+          status: schedulerVm.status,
+          allocatedAt: schedulerVm.allocated_at || undefined,
+          migrationTarget: schedulerVm.migration_target || undefined,
+        }
+      : undefined
 
     const hash = executable.id
 
+    // No reachable CRN: surface the scheduler view so the UI can show the
+    // scheduling progress (pre-allocation or unknown node).
+    if (!node?.address) {
+      if (!scheduler) return
+
+      return this.buildSchedulerOnlyStatus(hash, node, scheduler)
+    }
+
+    const nodeUrl = NodeManager.normalizeUrl(node.address)
+
+    let version: 'v1' | 'v2'
+    let response: unknown
+
+    try {
+      ;({ version, json: response } = await this.fetchExecutions(nodeUrl))
+    } catch {
+      // CRN unreachable: drop the cached allocation so the next poll
+      // re-resolves via the scheduler (covers migrations).
+      this.invalidateSchedulerAllocation(hash)
+      if (!scheduler) return
+
+      return this.buildSchedulerOnlyStatus(hash, node, scheduler)
+    }
+
     const executionStatus = (response as any)[hash]
-    if (!executionStatus) return
+    if (!executionStatus) {
+      // The allocated CRN no longer lists the VM: re-resolve next poll.
+      this.invalidateSchedulerAllocation(hash)
+      if (!scheduler) return
+
+      return this.buildSchedulerOnlyStatus(hash, node, scheduler)
+    }
 
     const networking = executionStatus['networking']
     if (!networking) return
@@ -253,6 +308,7 @@ export abstract class ExecutableManager<T extends Executable> {
         ipv6,
         ipv6Parsed: this.formatVMIPv6Address(ipv6),
         node,
+        scheduler,
       }
     } else if (version === 'v2') {
       const {
@@ -277,6 +333,7 @@ export abstract class ExecutableManager<T extends Executable> {
       return {
         version: 'v2',
         node,
+        scheduler,
         hash,
         hostIpv4,
         ipv4,
@@ -298,7 +355,85 @@ export abstract class ExecutableManager<T extends Executable> {
     }
   }
 
+  protected buildSchedulerOnlyStatus(
+    hash: string,
+    node: CRN | undefined,
+    scheduler: ExecutableSchedulerStatus,
+  ): ExecutableStatus {
+    return {
+      version: 'v2',
+      hash,
+      ipv4: '',
+      ipv6: '',
+      ipv6Parsed: '',
+      node,
+      scheduler,
+    }
+  }
+
+  protected async getSchedulerVm(
+    vmHash: string,
+  ): Promise<SchedulerVm | undefined> {
+    const cached = this.schedulerAllocations.get(vmHash)
+    if (cached) return cached
+
+    const vm = await fetchSchedulerVm(vmHash)
+    if (vm?.allocated_node) this.schedulerAllocations.set(vmHash, vm)
+
+    return vm
+  }
+
+  protected invalidateSchedulerAllocation(vmHash: string): void {
+    this.schedulerAllocations.delete(vmHash)
+  }
+
+  protected async resolveCRNByHash(nodeHash: string): Promise<CRNSpecs> {
+    const nodes = await this.nodeManager.getAllCRNsSpecs()
+
+    const node = nodes.find((node) => node.hash === nodeHash)
+    if (node) return node
+
+    // CRNs missing from the node collection: the scheduler node record still
+    // carries the address, so status queries and operations keep working.
+    const schedulerNode = await fetchSchedulerNode(nodeHash)
+
+    const { latest: latestVersion } =
+      await this.nodeManager.getLatestCRNVersion()
+
+    return {
+      hash: nodeHash,
+      name: schedulerNode?.name || undefined,
+      owner: schedulerNode?.owner || '',
+      address: schedulerNode?.address || undefined,
+      stream_reward: schedulerNode?.payment_receiver || undefined,
+      reward: '',
+      locked: false,
+      time: 0,
+      score: 0,
+      score_updated: true,
+      decentralization: 0,
+      performance: 0,
+      status: 'linked',
+      parent: null,
+      type: 'compute',
+      version: latestVersion || undefined,
+    }
+  }
+
   async getAllocationCRN(executable: T): Promise<CRNSpecs | undefined> {
+    // Scheduler-first: the scheduler is the source of truth for where a VM
+    // is allocated (covers network-assigned nodes and migrations). The legacy
+    // resolution below remains as fallback for VMs it does not know.
+    const schedulerVm = await this.getSchedulerVm(executable.id)
+    if (schedulerVm?.allocated_node)
+      return this.resolveCRNByHash(schedulerVm.allocated_node)
+
+    return this.getAllocationCRNLegacy(executable)
+  }
+
+  protected async getAllocationCRNLegacy(
+    executable: T,
+  ): Promise<CRNSpecs | undefined> {
     if (executable.payment?.type === PaymentType.superfluid) {
       const { receiver } = executable.payment
       if (!receiver) return

--- a/src/domain/instance.ts
+++ b/src/domain/instance.ts
@@ -603,7 +603,9 @@ export class InstanceManager<T extends InstanceEntity = Instance>
     newInstance: AddInstance,
     entity: InstanceEntity,
   ): AsyncGenerator<void, void, void> {
-    if (!newInstance.node || !newInstance.node.address) throw Err.InvalidNode
+    // No targeted CRN (network-assigned node): nothing to notify, the
+    // scheduler handles allocation.
+    if (!newInstance.node?.address) return
 
     yield
     await this.notifyCRNAllocation(newInstance.node, entity.id, {

--- a/src/domain/scheduler.ts
+++ b/src/domain/scheduler.ts
@@ -1,0 +1,99 @@
+import { schedulerApiUrl } from '@/helpers/constants'
+
+export type SchedulerVmStatus =
+  | 'scheduled'
+  | 'dispatched'
+  | 'migrating'
+  | 'duplicated'
+  | 'misplaced'
+  | 'missing'
+  | 'orphaned'
+  | 'unscheduled'
+  | 'unschedulable'
+  | 'unknown'
+
+export type SchedulerVmType = 'micro_vm' | 'persistent_program' | 'instance'
+
+// Response shape of GET /api/v1/vms/{vm_hash} (scheduler-api VmResponse).
+// `status` is the DERIVED effective status (scheduled = allocated but never
+// observed, dispatched = observed on the allocated node, missing = observed
+// nowhere); `scheduling_status` is the raw stored status.
+export type SchedulerVm = {
+  vm_hash: string
+  name: string | null
+  vm_type: SchedulerVmType
+  allocated_node: string | null
+  allocated_at: string | null
+  observed_nodes: string[] | null
+  last_observed_at: string | null
+  status: SchedulerVmStatus
+  scheduling_status: SchedulerVmStatus | null
+  requirements_vcpus: number | null
+  requirements_memory_mb: number | null
+  requirements_disk_mb: number | null
+  payment_type: string | null
+  payment_status: 'validated' | 'invalidated' | null
+  updated_at: string
+  requires_confidential: boolean | null
+  gpu_requirements: unknown[] | null
+  cpu_architecture: string | null
+  cpu_vendor: string | null
+  cpu_features: string[] | null
+  owner: string | null
+  sender: string | null
+  migration_target: string | null
+  migration_started_at: string | null
+}
+
+// Response shape of GET /api/v1/nodes/{node_hash} (scheduler-api
+// NodeResponse). Only the fields the console consumes are typed here.
+export type SchedulerNode = {
+  node_hash: string
+  name: string | null
+  owner: string | null
+  address: string | null
+  status: string
+  staked: boolean
+  supports_ipv6: boolean | null
+  confidential_computing_enabled: boolean | null
+  payment_receiver: string | null
+  vm_count: number
+  updated_at: string
+}
+
+/**
+ * Fetches the scheduler allocation entry for a VM. Returns undefined when the
+ * scheduler does not know the VM (404) or the request fails, so callers can
+ * fall back to the legacy allocation resolution.
+ */
+export async function fetchSchedulerVm(
+  vmHash: string,
+): Promise<SchedulerVm | undefined> {
+  try {
+    const res = await fetch(`${schedulerApiUrl}/api/v1/vms/${vmHash}`)
+    if (!res.ok) return
+
+    return (await res.json()) as SchedulerVm
+  } catch {
+    return
+  }
+}
+
+/**
+ * Fetches a node record from the scheduler. Returns undefined when the
+ * scheduler does not know the node (404) or the request fails. Used to
+ * resolve the address of allocated CRNs that are missing from the node
+ * collection.
+ */
+export async function fetchSchedulerNode(
+  nodeHash: string,
+): Promise<SchedulerNode | undefined> {
+  try {
+    const res = await fetch(`${schedulerApiUrl}/api/v1/nodes/${nodeHash}`)
+    if (!res.ok) return
+
+    return (await res.json()) as SchedulerNode
+  } catch {
+    return
+  }
+}

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -23,6 +23,7 @@ export const splTokenAddress = '3UCMiSnkcnkPE1pgQ5ggPCBv6dXgVUy16TmMUe1WpG9x'
 export const vouchersAddress = '0xB34f25f2c935bCA437C061547eA12851d719dEFb'
 
 export const crnListProgramUrl = 'https://crns-list.aleph.sh/crns.json'
+export const schedulerApiUrl = 'https://rust-scheduler.aleph.im'
 
 export const websiteUrl = 'https://www.aleph.cloud'
 

--- a/src/helpers/executableStatus.ts
+++ b/src/helpers/executableStatus.ts
@@ -25,7 +25,23 @@ export function calculateExecutableStatus(
   if (executableType === EntityType.Program) return 'v1'
 
   const latestStatus = getLatestStatusTimestamp(status)
-  if (!latestStatus) return 'not-allocated'
+  if (!latestStatus) {
+    // No runtime info from the CRN yet: fall back to the scheduler view.
+    const schedulerStatus = status?.scheduler?.status
+    if (!schedulerStatus) return 'not-allocated'
+
+    switch (schedulerStatus) {
+      case 'unscheduled':
+      case 'unschedulable':
+      case 'unknown':
+        return 'not-allocated'
+      default:
+        // scheduled / dispatched / migrating / …: the scheduler is placing
+        // (or has placed) the VM but the CRN has not reported runtime status
+        // yet. CRN data takes over as soon as it is available.
+        return 'preparing'
+    }
+  }
 
   switch (latestStatus.latestKey) {
     case 'stoppedAt':

--- a/src/helpers/schemas/instance.ts
+++ b/src/helpers/schemas/instance.ts
@@ -140,23 +140,39 @@ export const instanceBaseSchema = z
   })
   .merge(addNameAndTagsSchema)
 
-export const instanceSchema = instanceBaseSchema
-  .merge(
-    z.object({
-      nodeSpecs: nodeSpecsSchema,
-    }),
-  )
-  .refine(
-    ({ nodeSpecs, specs }) => {
-      return NodeManager.validateMinNodeSpecs(specs, nodeSpecs)
-    },
-    {
-      message: 'Insufficient node specs',
-      path: ['specs'],
-    },
-  )
-  .superRefine(checkMinCRNRequirements)
-  .superRefine(checkMinInstanceSystemVolumeSize)
+// Builds the instance schema with a configurable `nodeSpecs` field so regular
+// and GPU instances can differ only in whether a CRN is required, while sharing
+// the same node-dependent refinements.
+function buildInstanceSchema<T extends z.ZodTypeAny>(nodeSpecsField: T) {
+  return instanceBaseSchema
+    .merge(
+      z.object({
+        nodeSpecs: nodeSpecsField,
+      }),
+    )
+    .refine(
+      ({ nodeSpecs, specs }) => {
+        // No selected CRN (network-assigned node): skip the node-specific specs
+        // check. When a CRN is present, validate it against the tier.
+        if (!nodeSpecs) return true
+        return NodeManager.validateMinNodeSpecs(specs, nodeSpecs)
+      },
+      {
+        message: 'Insufficient node specs',
+        path: ['specs'],
+      },
+    )
+    .superRefine(checkMinCRNRequirements)
+    .superRefine(checkMinInstanceSystemVolumeSize)
+}
+
+// Regular instances: the network assigns a compatible CRN by default, so
+// `nodeSpecs` is only present when the user manually selects a node.
+export const instanceSchema = buildInstanceSchema(nodeSpecsSchema.optional())
+
+// GPU instances: a GPU is bound to a physical CRN, so a node (and its specs) is
+// always required — preserves the pre-existing validation.
+export const gpuInstanceSchema = buildInstanceSchema(nodeSpecsSchema)
 
 // REFINEMENTS
 
@@ -164,6 +180,9 @@ async function checkMinCRNRequirements(
   { nodeSpecs, specs, volumes = [] }: any,
   ctx: RefinementCtx,
 ) {
+  // No manually selected CRN: node capacity is enforced by the network.
+  if (!nodeSpecs) return
+
   let available = nodeSpecs.disk.available_kB / 1024
 
   for (const [i, volume] of Object.entries<any>(volumes)) {


### PR DESCRIPTION
## Summary

  Instances no longer pin a CRN by default. The create message only includes `requirements.node.node_hash` when the user manually selects a node in the advanced options — otherwise
  the network scheduler places the VM. Since auto-assigned instances have no node in the message, detail pages now resolve where a VM runs (and its scheduling status) through the
  rust-scheduler API.

  ## Instance creation

  - **No CRN auto-selection**: the node is derived solely from a manual selection in the advanced "Custom Node Selection" section; the auto-select path and the `manualNodeOverride`
  state are removed.
  - The CRN resource reservation pre-flight only runs when a node is manually selected; with no node the instance is created directly and the scheduler handles placement.
  - The targeted-CRN allocation notify is skipped when no node is set.
  - UI: node info and reservation status are hidden until a CRN is manually selected (moved into the advanced section).
  - Validation: `nodeSpecs` is now optional for regular instances (node-dependent refinements are skipped when absent). GPU instances keep it required via a dedicated
  `gpuInstanceSchema` — a GPU is bound to a physical CRN, so their behavior is unchanged.

  ## Allocation resolution (all executables)

  - New `src/domain/scheduler.ts` client for the rust-scheduler API (`/api/v1/vms/{hash}`, `/api/v1/nodes/{hash}`).
  - `getAllocationCRN` queries the scheduler first (`allocated_node` → CRN specs lookup); the previous resolution (requirements node hash → stream receiver → legacy python
  scheduler) is preserved verbatim as fallback for VMs the scheduler does not know.
  - Allocations are cached once a node is allocated, so the 10s status polls go straight to the CRN. The cache is invalidated when the CRN becomes unreachable or no longer lists the
  VM (covers migrations).
  - `ExecutableStatus` gains an optional `scheduler` block; `calculateExecutableStatus` maps scheduler states when the CRN has no runtime data yet
  (`unscheduled`/`unschedulable`/`unknown` → not-allocated, otherwise preparing). CRN runtime data always wins once available.
  - When the allocated CRN is missing from the node collection, the scheduler node record still provides its address/name, so status queries and operations keep working.

  ## Verification

  - `npm run lint` + `npm run build` green.
  - Created instances on this branch and inspected the signed messages:
    - no manual selection → no `requirements.node` ([example](https://api2.aleph.im/api/v0/messages/fced4910157a8cfd3cf544e2638c0af320be3e55c9e69f5190c6ae42176f15ea))
    - manual CRN → `node_hash` present ([example](https://api2.aleph.im/api/v0/messages/066d7272c70fb36bb865efa8a9a9d28e4f3225b405352f6fbd044af253a43564))
  - Detail page of a network-assigned instance resolves the allocated node and live status end-to-end (scheduler → node record → CRN executions), verified in the running app.
