### PR TITLE
fix: display credit top-up API error messages

### DIFF
--- a/src/components/modals/TopUpCreditsModal/hook.ts
+++ b/src/components/modals/TopUpCreditsModal/hook.ts
@@ -331,13 +331,15 @@ export function useTopUpCreditsModalForm({
     return hasManuallyChangedAmount && isBelowMinimumCredits
   }, [hasManuallyChangedAmount, isBelowMinimumCredits])
 
-  // Disable submit if amount is insufficient for the minimum requirement
+  // Without an estimation the minimum cannot be checked, so stay disabled
   const isSubmitDisabled = useMemo(() => {
     return (
       !values.amount ||
       values.amount <= 0 ||
       isSubmitLoading ||
       isCalculatingInitialAmount ||
+      isLoadingEstimation ||
+      !estimation ||
       isBelowMinimumCredits ||
       !isEthereumNetwork
     )
@@ -345,6 +347,8 @@ export function useTopUpCreditsModalForm({
     values.amount,
     isSubmitLoading,
     isCalculatingInitialAmount,
+    isLoadingEstimation,
+    estimation,
     isBelowMinimumCredits,
     isEthereumNetwork,
   ])

--- a/src/domain/credit.ts
+++ b/src/domain/credit.ts
@@ -293,16 +293,13 @@ export class CreditManager {
     const blockchain = data.chain
     const token = data.currency
 
-    // Convert amount to smallest unit based on token decimals
-    const amount = toTokenSmallestUnit(data.amount, token)
-
-    const estimationRequest: TokenEstimationRequest = {
-      blockchain,
-      token,
-      amount,
-    }
-
     try {
+      const estimationRequest: TokenEstimationRequest = {
+        blockchain,
+        token,
+        amount: toTokenSmallestUnit(data.amount, token),
+      }
+
       const response = await fetch(ALEPH_CREDIT_TOKEN_TO_CREDIT_ENDPOINT, {
         method: 'POST',
         headers: {
@@ -318,7 +315,7 @@ export class CreditManager {
       return response.json()
     } catch (error) {
       console.error('Error fetching token estimation:', error)
-      throw new Error('Failed to fetch token estimation')
+      throw error
     }
   }
 
@@ -361,7 +358,7 @@ export class CreditManager {
       }
     } catch (error) {
       console.error('Error fetching credit to token estimation:', error)
-      throw new Error('Failed to fetch credit to token estimation')
+      throw error
     }
   }
 

--- a/src/domain/credit.ts
+++ b/src/domain/credit.ts
@@ -1,7 +1,6 @@
 import { Account } from '@aleph-sdk/account'
 import { ETHAccount } from '@aleph-sdk/ethereum'
 import { v4 as uuidv4 } from 'uuid'
-import BN from 'bn.js'
 import { CheckoutStepType } from '@/helpers/constants'
 import {
   TopUpCreditsFormData,
@@ -13,6 +12,7 @@ import {
   CreditEstimationRequest,
   CreditEstimationResponse,
 } from '@/helpers/schemas/credit'
+import { apiResponseError } from '@/helpers/errors'
 import { sleep, withRetry } from '@/helpers/utils'
 import { DEFAULT_PAGE_SIZE, DEFAULT_DELAY_MS } from '@/helpers/pagination'
 
@@ -40,21 +40,19 @@ export function getTokenDecimals(token: TokenId | string): number {
 }
 
 /**
- * Get the decimal multiplier for a token (e.g., 10^18 for ALEPH, 10^6 for USDC)
- */
-export function getTokenMultiplier(token: TokenId | string): BN {
-  const decimals = getTokenDecimals(token)
-  return new BN('1'.padEnd(decimals + 1, '0'))
-}
-
-/**
- * Convert a token amount to its smallest unit (e.g., 1 USDC -> 1000000)
+ * Convert a token amount to its smallest unit (e.g., 1.5 USDC -> 1500000)
+ * Decimals beyond the token precision are truncated
  */
 export function toTokenSmallestUnit(
   amount: number | string,
   token: TokenId | string,
 ): string {
-  return new BN(amount.toString()).mul(getTokenMultiplier(token)).toString()
+  const decimals = getTokenDecimals(token)
+  const [whole, fraction = ''] = amount.toString().split('.')
+
+  return BigInt(
+    `${whole}${fraction.slice(0, decimals).padEnd(decimals, '0')}`,
+  ).toString()
 }
 
 /**
@@ -219,13 +217,7 @@ export class CreditManager {
       })
 
       if (!response.ok) {
-        const error = await response.json().catch((e) => e)
-
-        if (error.description) {
-          throw new Error(`${error.description}`)
-        }
-
-        throw new Error(`API error: ${response.status} ${response.statusText}`)
+        throw await apiResponseError(response)
       }
 
       return response.json()
@@ -320,13 +312,7 @@ export class CreditManager {
       })
 
       if (!response.ok) {
-        const error = await response.json().catch((e) => e)
-
-        if (error.description) {
-          throw new Error(`${error.description}`)
-        }
-
-        throw new Error(`API error: ${response.status} ${response.statusText}`)
+        throw await apiResponseError(response)
       }
 
       return response.json()
@@ -358,13 +344,7 @@ export class CreditManager {
       })
 
       if (!response.ok) {
-        const error = await response.json().catch((e) => e)
-
-        if (error.description) {
-          throw new Error(`${error.description}`)
-        }
-
-        throw new Error(`API error: ${response.status} ${response.statusText}`)
+        throw await apiResponseError(response)
       }
 
       const data = await response.json()
@@ -410,15 +390,7 @@ export class CreditManager {
         )
 
         if (!response.ok) {
-          const error = await response.json().catch((e) => e)
-
-          if (error.description) {
-            throw new Error(`${error.description}`)
-          }
-
-          throw new Error(
-            `API error: ${response.status} ${response.statusText}`,
-          )
+          throw await apiResponseError(response)
         }
 
         const result = await response.json()

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -1,3 +1,29 @@
+type ApiErrorBody = {
+  description?: string
+  message?: string
+  // Zod errors carry their explanation here, not in `message`
+  issues?: { message?: string }[]
+}
+
+/**
+ * Builds a readable error from a failed API response, falling back to the
+ * status when the body carries no usable message
+ */
+export async function apiResponseError(response: Response): Promise<Error> {
+  const body: ApiErrorBody = await response.json().catch(() => ({}))
+  const message =
+    body.issues
+      ?.map((issue) => issue.message)
+      .filter(Boolean)
+      .join('. ') ||
+    body.description ||
+    body.message
+
+  return new Error(
+    message || `API error: ${response.status} ${response.statusText}`,
+  )
+}
+
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
   ChainNotYetSupported: new Error('Chain is not yet supported'),


### PR DESCRIPTION
Reported on Telegram: topping up with a fractional amount fails with an unreadable `Error: API error: 400`.

## Cause

`toTokenSmallestUnit` built a BN from the raw amount, and BN.js rejects `.` with `Invalid character`. It is called outside the `try` in `getTokenToCreditsEstimation`, so any fractional amount left `estimation` null — which is why the modal showed `~ $0.00 bonus / balance`.

`isBelowMinimumCredits` can only be `true` *with* an estimation, so the existing `MIN_CREDITS_TOPUP` guard silently went inert and the request reached the API. The server rejected it with a Zod body the frontend did not read:

```json
{ "issues": [{ "code": "custom", "message": "Amount too low. Minimum $1 worth of credits (1,000,000 credits)...", "path": ["body", "amount"] }], "name": "ZodError" }
```

Only `error.description` was handled, so it fell through to the status line. Integer amounts worked, which is why this went unnoticed.

## Changes

- `apiResponseError` in `helpers/errors.ts` — reads Zod `issues[].message`, then `description`, then `message`, falling back to the status line. Replaces four copies of the same block in `credit.ts`.
- `toTokenSmallestUnit` shifts digits with BigInt instead of BN, so decimals convert. Drops `getTokenMultiplier` and the `bn.js` import, orphaned by this.
- `isSubmitDisabled` also requires a settled estimation, so a failed one can no longer leave the button enabled.

## Testing

Conversion and error-body parsing were checked under node (`0.3` → `300000`, integers unchanged, ALEPH 18-decimals, truncation; the payload above plus `description` / `message` / empty / non-JSON bodies).

`npm run lint:fix` and `npm run build` could **not** be run — `npm i` fails with `E401` against `npm.fontawesome.com` (expired Font Awesome Pro token), so there is no `node_modules` locally. Please confirm CI is green; prettier may want to reformat the `body.issues?.map(...)` chain.

Note `0,3` in the report is display-only: `<input type="number">` normalizes `.value` to a period decimal, so a French-locale browser renders `0,3` while the handler receives `0.3`.